### PR TITLE
Fix JWT decode in sync function

### DIFF
--- a/js/1-event-management.js
+++ b/js/1-event-management.js
@@ -1759,9 +1759,13 @@ async function syncDatecycles() {
 
         let decoded = null;
         try {
-            decoded = jwt_decode(token);
+            const parts = token.split('.');
+            if (parts.length !== 3) {
+                throw new Error('Invalid JWT format');
+            }
+            decoded = JSON.parse(atob(parts[1]));
         } catch (e) {
-            console.error("Failed to decode JWT:", e);
+            console.error('Failed to decode JWT:', e);
             return;
         }
 


### PR DESCRIPTION
## Summary
- properly decode access token without external dependency

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688113663be8832bbc821dfcbf16433e