### PR TITLE
Load calendar SVG before initialization

### DIFF
--- a/dash-2.html
+++ b/dash-2.html
@@ -436,13 +436,19 @@
         //Initiate
         gsap.registerPlugin(MotionPathPlugin);
 
-        // let user_timezone = localStorage.getItem("user_timezone") || Intl.DateTimeFormat().resolvedOptions().timeZone;
+        async function loadCalendarSvg() {
+            const response = await fetch('cals/earthcal-v1.0.svg');
+            const svgText = await response.text();
+            document.getElementById('the-cal').innerHTML = svgText;
+        }
 
+        // let user_timezone = localStorage.getItem("user_timezone") || Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 
 
         /*ROLL CALL*/
         window.onload = async function () {
+            await loadCalendarSvg();
 
 
 


### PR DESCRIPTION
## Summary
- Fetch `cals/earthcal-v1.0.svg` and inject it into `#the-cal`
- Remove redundant `svgs/earthcal.svg` symlink
- Delay roll call initialization until the SVG is loaded

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68733ee24030832b8476180a6289fc71