### PR TITLE
refactor scripts to wait for svg load

### DIFF
--- a/dash-2.html
+++ b/dash-2.html
@@ -101,10 +101,10 @@
     <!--This loads the main calendar javascript -->
 
     <script src="js/core-javascripts.js?v=2"></script> <!--functional scripts-->
-    <script src="js/breakouts.js"></script> <!--breakout control scripts-->
+    <script src="js/breakouts-2.js"></script> <!--breakout control scripts-->
     <script src="js/set-targetdate.js"></script> <!--functional scripts-->
     <script src="js/1-lunar-scripts.js"></script><!-- concerning the moon-->
-    <script src="js/planet-orbits.js"></script><!--planets-->
+    <script src="js/planet-orbits-2.js"></script><!--planets-->
     <script src="js/login-scripts.js"></script><!--planets-->
     <script src="js/time-setting.js"></script><!--setting user time, timezone, clock-->
 
@@ -440,6 +440,7 @@
             const response = await fetch('cals/earthcal-v1.0.svg');
             const svgText = await response.text();
             document.getElementById('the-cal').innerHTML = svgText;
+            document.dispatchEvent(new Event('svgLoaded'));
         }
 
         // let user_timezone = localStorage.getItem("user_timezone") || Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -1511,7 +1512,7 @@
 
 
 <script src="js/1-event-management.js?v=2"></script>
-<script src="js/calendar-scripts.js"></script>
+<script src="js/calendar-scripts-2.js"></script>
 <script src="js/kin-cycles.js"></script>
 
 

--- a/js/breakouts-2.js
+++ b/js/breakouts-2.js
@@ -1,0 +1,411 @@
+
+
+/*************************
+
+ // BREAKOUTS
+
+
+ /*****************************/
+
+
+/* BREAKOUT SCRIPTS */
+
+
+//Open the current month breakout (on load)
+function openCurrentMonthBreakout() {
+    // Array of month names in lowercase to match element IDs
+    const monthNames = [
+        'january', 'february', 'march', 'april', 'may', 'june',
+        'july', 'august', 'september', 'october', 'november', 'december',
+    ];
+
+    // Get today's date
+    const today = new Date();
+
+    // Determine the current month and year
+    const currentMonthNumber = today.getMonth() + 1; // Months are 0-based, so add 1
+    const currentMonthName = monthNames[today.getMonth()]; // Get the name of the current month
+
+    // Call breakoutTheMonth for the current month
+    breakoutTheMonth(currentMonthName, currentMonthNumber);
+}
+
+
+
+
+function triggerBreakoutDay() {
+    //alert('hello!');
+    // Parent container for all day-breakout elements
+    const breakoutContainer = document.querySelector('svg'); // Adjust this selector to target the appropriate container for day elements
+
+    // Check if container exists
+    if (!breakoutContainer) return;
+
+    // Add a single click listener to the container (event delegation)
+    breakoutContainer.addEventListener('click', function (event) {
+        const clickedElement = event.target.closest('g[id*="day-breakout"]');
+
+        // Ensure the clicked element is a valid day-breakout group
+        if (!clickedElement) return;
+
+        // Remove the "active-break" class from all day-breakout elements
+        document.querySelectorAll('g.active-break').forEach(group => {
+            group.classList.remove('active-break');
+        });
+
+        // Add the "active-break" class to the clicked element
+        clickedElement.classList.add('active-break');
+
+        // Determine the year from the targetDate or default to the current year
+        const year = targetDate instanceof Date ? targetDate.getFullYear() : new Date().getFullYear();
+
+        // Extract day and month from the ID (e.g., "01-05-day-breakout")
+        const idParts = clickedElement.id.split('-');
+        const day = parseInt(idParts[0], 10); // First part is the day
+        const month = parseInt(idParts[1], 10) - 1; // Second part is the month (adjusted for zero index)
+
+        // Update the global targetDate with the new date
+        targetDate = new Date(year, month, day);
+
+
+        // Refresh the calendar
+        calendarRefresh();
+    });
+}
+
+
+
+
+
+
+// LISTEN FOR BREAKOUT CLICK
+function listenForMonthBreakout() {
+    const monthNames = [
+        'january', 'february', 'march', 'april', 'may', 'june',
+        'july', 'august', 'september', 'october', 'november', 'december',
+    ];
+
+    monthNames.forEach((month) => {
+        const monthDiv = document.getElementById(`${month}_366`);
+        const monthNumber = monthNames.indexOf(month) + 1;
+
+        // Listen for click on the monthDiv
+        monthDiv.addEventListener('click', () => {
+            breakoutTheMonth(month, monthNumber); // Delegate the logic to breakoutTheMonth
+        });
+    });
+}
+
+
+
+
+
+function breakoutTheMonth(monthName, monthNumber) {
+    closeCurrentBreakout(() => {
+        const monthBreakout = document.getElementById(`${monthName}-breakout`);
+        const solarCenterDiv = document.getElementById('solar-system-center');
+        const dayLinesDiv = document.getElementById('days-of-year-lines');
+        const allDaymarkers = document.getElementById('all-daymarkers');
+        const lunarMonths = document.getElementById('lunar_months-12');
+        const monthIntentions = document.getElementById(`${monthName}-intentions`);
+        const intentionsDiv = document.getElementById(`${monthName}-intention-month-name`);
+
+        // Function to change the display style of day divs and possibly add a class
+        const setDisplay = (id, displayStyle, addClass) => {
+            const element = document.getElementById(id);
+            if (element) {
+                element.style.display = displayStyle;
+                if (addClass) {
+                    element.classList.add(addClass);
+                }
+            }
+        };
+
+        // Fade out general calendar elements
+        allDaymarkers.style.opacity = '0';
+        dayLinesDiv.style.opacity = '0';
+        lunarMonths.style.opacity = '0';
+        lunarMonths.style.pointerEvents = 'none';
+        intentionsDiv.style.display = 'block';
+
+        // Fade out the solar center and highlight the clicked month
+        setTimeout(() => {
+            solarCenterDiv.style.opacity = '0';
+            document.getElementById(`${monthName}_366`).style.opacity = '1';
+        }, 500);
+
+        // Show the breakout view after delay
+        setTimeout(() => {
+            monthBreakout.style.display = 'block';
+
+            // Get the current year from the div with id 'current-year'
+            const currentYear = parseInt(document.getElementById('current-year').textContent);
+
+            // Get today's date
+            const today = new Date();
+            const isCurrentMonth = today.getFullYear() === currentYear && today.getMonth() + 1 === monthNumber;
+
+            // Determine if the targetDate is within the breakout month
+            const isTargetDateInBreakoutMonth = targetDate &&
+                targetDate.getFullYear() === currentYear &&
+                targetDate.getMonth() + 1 === monthNumber;
+
+            // Only update targetDate if the selected month does not contain the current date
+            if (!isCurrentMonth) {
+                targetDate = new Date(currentYear, monthNumber - 1, 1); // Set to the first day of the selected month
+            }
+
+            // Set all day div groups to display none
+            const daysInMonth = new Date(currentYear, monthNumber, 0).getDate(); // Get the number of days in the month
+            for (let i = 1; i <= daysInMonth; i++) {
+                let dayId = `${i.toString().padStart(2, '0')}-${monthNumber.toString().padStart(2, '0')}-day-breakout`;
+                setDisplay(dayId, 'none');
+            }
+
+            // Sequentially set each day div to display block
+            for (let i = 1; i <= daysInMonth; i++) {
+                let dayId = `${i.toString().padStart(2, '0')}-${monthNumber.toString().padStart(2, '0')}-day-breakout`;
+                setTimeout(() => setDisplay(dayId, 'block'), i * 22); // 0.22 seconds apart
+            }
+
+            // Highlight the appropriate day:
+            const dayToHighlight = isCurrentMonth
+                ? today.getDate().toString().padStart(2, '0') // Highlight today's date if in breakout month
+                : isTargetDateInBreakoutMonth
+                    ? targetDate.getDate().toString().padStart(2, '0') // Highlight targetDate if within breakout month
+                    : '01'; // Otherwise, highlight the first day of the month
+
+            const highlightDayId = `${dayToHighlight}-${monthNumber.toString().padStart(2, '0')}-day-breakout`;
+            setTimeout(() => setDisplay(highlightDayId, 'block', 'active-break'), 800);
+
+            // Update breakout days of the week
+            updateBreakoutDaysOfWeek(targetDate);
+
+            calendarRefresh();
+            listenForCloseBreakout(); // Initialize the close listeners after refreshing the calendar
+        }, 700);
+
+        // Show and fade in the intentions section for the month
+        setTimeout(() => {
+            monthIntentions.style.display = 'block';
+            monthIntentions.style.opacity = '1';
+        }, 1000);
+    });
+}
+
+
+
+// LISTEN FOR BREAKOUT CLOSE CLICK
+
+function listenForCloseBreakout() {
+    const monthNames = [
+        'january', 'february', 'march', 'april', 'may', 'june',
+        'july', 'august', 'september', 'october', 'november', 'december'
+    ];
+
+    monthNames.forEach(month => {
+        const monthBreakoutCloseDiv = document.getElementById(`${month}-breakout-close`);
+
+        if (monthBreakoutCloseDiv) {
+            monthBreakoutCloseDiv.addEventListener('click', () => {
+                console.log("Close button clicked:", monthBreakoutCloseDiv.id); // Debug log
+
+                closeCurrentBreakout(() => {
+                    const solarCenterDiv = document.getElementById('solar-system-center');
+                    const dayLinesDiv = document.getElementById('days-of-year-lines');
+                    const allDaymarkers = document.getElementById('all-daymarkers');
+                    const lunarMonths = document.getElementById('lunar_months-12');
+                    const theMonth = document.getElementById(`${month}_366`);
+
+                    setTimeout(() => {
+                        dayLinesDiv.style.opacity = '1';
+                        theMonth.style.opacity = '0.66';
+                    }, 0);
+
+                    setTimeout(() => {
+                        solarCenterDiv.style.opacity = '1';
+                        lunarMonths.style.opacity = '1';
+                    }, 800);
+
+                    setTimeout(() => {
+                        allDaymarkers.style.opacity = '1';
+                    }, 1500);
+                });
+            });
+        }
+    });
+}
+
+
+function closeCurrentBreakout(callback) {
+    const monthNames = [
+        'january', 'february', 'march', 'april', 'may', 'june',
+        'july', 'august', 'september', 'october', 'november', 'december'
+    ];
+
+    // Function to change the display style of day divs and possibly add a class
+    const setDisplay = (id, displayStyle, addClass) => {
+        const element = document.getElementById(id);
+        if (element) {
+            element.style.display = displayStyle;
+            if (addClass) {
+                element.classList.add(addClass);
+            }
+        }
+    };
+
+    let closeDuration = 0;
+    let closeOperations = [];
+
+    monthNames.forEach(month => {
+        const otherMonthBreakout = document.getElementById(`${month}-breakout`);
+        const otherMonthIntentions = document.getElementById(`${month}-intentions`);
+        if (otherMonthBreakout && otherMonthBreakout.style.display === 'block') {
+            const daysInOtherMonth = new Date(2024, monthNames.indexOf(month) + 1, 0).getDate();
+            for (let i = daysInOtherMonth; i >= 1; i--) {
+                let dayId = `${i.toString().padStart(2, '0')}-${(monthNames.indexOf(month) + 1).toString().padStart(2, '0')}-day-breakout`;
+                closeOperations.push(() => setDisplay(dayId, 'none'));
+            }
+            closeDuration = daysInOtherMonth * 22 + 100;
+            closeOperations.push(() => { otherMonthBreakout.style.display = 'none'; });
+        }
+        if (otherMonthIntentions && otherMonthIntentions.style.display !== 'none') {
+            closeOperations.push(() => { otherMonthIntentions.style.display = 'none'; });
+        }
+    });
+
+    // Execute all close operations sequentially
+    closeOperations.forEach((operation, index) => {
+        setTimeout(operation, index * 22);
+    });
+
+    // Call the callback function after closing current breakouts
+    setTimeout(callback, closeDuration);
+}
+
+
+
+
+
+
+
+
+function updateBreakoutDaysOfWeek(targetDate) {
+    const daysInMonth = new Date(targetDate.getFullYear(), targetDate.getMonth() + 1, 0).getDate();
+    const dayNames = ['SUN', 'MON', 'TUE', 'WED', 'THU', 'FRI', 'SAT'];
+
+    for (let i = 1; i <= daysInMonth; i++) {
+        const dayOfWeek = new Date(targetDate.getFullYear(), targetDate.getMonth(), i).getDay();
+        const dayTextId = `break_out_text_${i.toString().padStart(2, '0')}_${(targetDate.getMonth() + 1).toString().padStart(2, '0')}`;
+        const dayTextDiv = document.getElementById(dayTextId);
+
+        if (dayTextDiv) {
+            const tspanElement = dayTextDiv.querySelector('tspan');
+            if (tspanElement) {
+                tspanElement.innerHTML = dayNames[dayOfWeek];
+            }
+        }
+    }
+
+//  alert(`Days of the week for ${targetDate.toDateString()} are set!`);
+}
+
+
+
+
+
+
+
+
+
+
+// Function to toggle the views for solar and lunar for a particular month
+function toggleMonthSolarLunarViews(month, type) {
+    const intentionsDiv = document.getElementById(`${month}-intention-month-name`);
+    const themoonphases = document.getElementById('themoonphases');
+    const solarCenterDiv = document.getElementById('solar-system-center');
+    const solarButton = document.getElementById(`${month}-solar_show-button`);
+    const lunarButton = document.getElementById(`${month}-lunar_show-button`);
+
+    if (type === 'solar') {
+        intentionsDiv.style.display = 'none';
+        themoonphases.style.display = 'none';
+        solarCenterDiv.style.opacity = '1';
+        if (solarButton) solarButton.style.display = 'none';
+        if (lunarButton) lunarButton.style.display = 'block';
+    } else if (type === 'lunar') {
+        intentionsDiv.style.display = 'block';
+        themoonphases.style.display = 'block';
+        solarCenterDiv.style.opacity = '0';
+        if (solarButton) solarButton.style.display = 'block';
+        if (lunarButton) lunarButton.style.display = 'none';
+    }
+}
+
+// Function to attach event listeners to all toggle buttons
+function attachEventListeners() {
+    const solarButtons = document.querySelectorAll('[id$="solar_show-button"]');
+    solarButtons.forEach(button => {
+        button.addEventListener('click', function() {
+            const month = this.id.split('-')[0]; // Extract the month from the button id
+            toggleMonthSolarLunarViews(month, 'solar');
+        });
+    });
+
+    const lunarButtons = document.querySelectorAll('[id$="lunar_show-button"]');
+    lunarButtons.forEach(button => {
+        button.addEventListener('click', function() {
+            const month = this.id.split('-')[0]; // Extract the month from the button id
+            toggleMonthSolarLunarViews(month, 'lunar');
+        });
+    });
+}
+
+// Attach event listeners when the DOM content is loaded
+
+
+// MONTH PHASE DISPLAY ON BREAKOUTS
+
+// Function to display moon phase on breakout touch or mouseover
+function displayMoonPhaseOnBreakoutTouch(event) {
+    const currentYear = parseInt(currentYearText.textContent); //imports the current year from the currentYearText element
+
+    let targetElement = event.target;
+
+    // Traverse up the DOM tree to find the <g> element if necessary
+    while (targetElement && targetElement.tagName !== 'g') {
+        targetElement = targetElement.parentNode;
+    }
+
+    // Ensure we have found the <g> element
+    if (targetElement && targetElement.tagName === 'g') {
+        const pathID = targetElement.id;
+        const dateParts = pathID.split('-');
+        const day = parseInt(dateParts[0]);
+        const month = parseInt(dateParts[1]) - 1; // month is 0-indexed in JavaScript
+        const year = currentYear; // Use the globally preset currentYear
+
+        const date = new Date(year, month, day);
+
+        // Call the displayMoonPhaseInDiv function to show the moon phase details for the selected date
+        displayMoonPhaseInDiv(date);
+        updateMoonPhase(date);
+    }
+}
+
+// Function to attach event listeners to all relevant SVG groups
+function attachBreakoutTouchListeners() {
+    const breakoutGroups = document.querySelectorAll('[id$="-day-breakout"]');
+    breakoutGroups.forEach(group => {
+        group.addEventListener('touchstart', displayMoonPhaseOnBreakoutTouch);
+        group.addEventListener('mouseover', displayMoonPhaseOnBreakoutTouch);
+    });
+}
+
+// Attach event listeners when the DOM content is loaded
+document.addEventListener('svgLoaded', () => {
+    attachEventListeners();
+    attachBreakoutTouchListeners();
+});
+
+

--- a/js/calendar-scripts-2.js
+++ b/js/calendar-scripts-2.js
@@ -1,0 +1,501 @@
+
+// References to the SVG elements (populated after SVG injection)
+let prevYear, nextYear, currentYearText, weekPaths;
+
+// Helper function to calculate the date range for each week
+function getWeekDateRange(year, week) {
+  const startDate = new Date(Date.UTC(year, 0, 1));
+  const dayOffset = (startDate.getUTCDay() + 6) % 7; // Calculate the day offset for the first bridging week
+  startDate.setUTCDate(1 - dayOffset); // Set the start date to the first day of the first bridging week
+  startDate.setUTCDate(startDate.getUTCDate() + (week - 1) * 7); // Set the start date to the first day of the requested week
+  const endDate = new Date(startDate.getTime());
+  endDate.setUTCDate(endDate.getUTCDate() + 6); // Set the end date to the last day of the requested week
+  const startDateString = startDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  const endDateString = endDate.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+  return `${startDateString} to ${endDateString}`;
+}
+
+// Function to update the week titles for the current year
+function updateWeekTitles(year) {
+  weekPaths.forEach((path) => {
+    const weekNumber = path.id.slice(5); // Get the week number from the path ID
+    const dateRange = getWeekDateRange(year, weekNumber);
+    path.setAttribute('title', dateRange);
+  });
+}
+
+
+function prevYearClick() {
+  const currentYear = parseInt(currentYearText.textContent);
+  currentYearText.textContent = (currentYear - 1).toString();
+  updateWeekTitles(currentYear - 1);
+  updateDayIds(currentYear - 1);
+  updateDayTitles(currentYear - 1);
+
+  targetDate = new Date((currentYear - 1), 0, 1);
+
+  const allPaths = document.querySelectorAll("svg path");
+  allPaths.forEach((path) => {
+    path.classList.remove("active");
+    path.classList.remove("final");
+  });
+
+  calendarRefresh();
+  setYearsMonthsOn();
+  startDate = targetDate;
+
+}
+
+function nextYearClick() {
+  const currentYear = parseInt(currentYearText.textContent);
+  currentYearText.textContent = (currentYear + 1).toString();
+  updateWeekTitles(currentYear + 1);
+  updateDayIds(currentYear + 1);
+  updateDayTitles(currentYear + 1);
+
+  targetDate = new Date((currentYear + 1), 0, 1);
+  setYearsMonthsOn()
+  const allPaths = document.querySelectorAll("svg path");
+  allPaths.forEach((path) => {
+    path.classList.remove("active");
+    path.classList.remove("final");
+  });
+
+  calendarRefresh();
+  updateTargetDay();
+  startDate = targetDate;
+
+}
+
+
+
+
+
+
+function updateDayIds(year) {
+  // Check if the year is a leap year
+  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || (year % 400 === 0);
+
+  // Select all paths including "-day" and "-day-marker", excluding paths with "lunar"
+  const dayPaths = document.querySelectorAll('path[id$="-day"]:not([id*="lunar"]), path[id$="-day-marker"]:not([id*="lunar"])');
+
+  dayPaths.forEach((path) => {
+    // Determine if the path ID ends with "-day" or "-day-marker"
+    const isDayMaker = path.id.endsWith('-day-marker');
+
+    // If it's not a leap year and the path is for the 366th day, change its ID accordingly
+    if (!isLeapYear && path.id.includes('366')) {
+      path.setAttribute('id', `366${isDayMaker ? '-day-marker' : '-day'}`);
+      return; // Skip further processing for this path
+    }
+
+    const idParts = path.id.split('-');
+    const day = parseInt(idParts[0]);
+    const date = new Date(year, 0, day);
+    const month = date.getMonth() + 1;
+    const dayOfMonth = date.getDate();
+    const yearString = year.toString();
+    const newId = `${day}-${dayOfMonth}-${month}-${yearString}${isDayMaker ? '-day-marker' : '-day'}`;
+    path.setAttribute('id', newId);
+  });
+
+  // alert('Is ' + year + ' a leap year? ' + isLeapYear);
+}
+
+
+
+function updateDayTitles(year) {
+  const dayPaths = document.querySelectorAll('path[id$="-day"]');/*Changed from $*/
+  dayPaths.forEach((path) => {
+    const dateParts = path.id.split('-');
+    const dayOfMonth = parseInt(dateParts[1]);
+    const month = parseInt(dateParts[2]) - 1; // month is 0-indexed in JavaScript
+    const date = new Date(year, month, dayOfMonth);
+    const dateString = date.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+    path.setAttribute('title', dateString);
+  });
+}
+
+
+function updateDayTitles(year) {
+  const dayPaths = document.querySelectorAll('path[id$="-day"]');
+  dayPaths.forEach((path) => {
+    const dateParts = path.id.split('-');
+    const dayOfMonth = parseInt(dateParts[1]);
+    const month = parseInt(dateParts[2]) - 1; // month is 0-indexed in JavaScript
+    const date = new Date(year, month, dayOfMonth);
+    const dateString = date.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+
+
+
+    path.setAttribute('title', `${dateString}`);
+  });
+}
+
+
+
+//Sets the Mouseover for the Moon Phases
+function formatDate(date) {
+    return date.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+  }
+
+  function getPhaseIndex(phase) {
+    const phaseIndex = Math.round(phase * 30);
+    return phaseIndex;
+  }
+
+  function getMoonPhaseEmoji(phase) {
+    const phaseIndex = getPhaseIndex(phase);
+    if (phaseIndex <= 1) return '🌑'; // New Moon
+    if (phaseIndex > 1 && phaseIndex <= 6) return '🌒'; // Waxing Crescent
+    if (phaseIndex > 6 && phaseIndex <= 9) return '🌓'; // First Quarter
+    if (phaseIndex > 9 && phaseIndex <= 14) return '🌔'; // Waxing Gibbous
+    if (phaseIndex > 14 && phaseIndex <= 16) return '🌕'; // Full Moon
+    if (phaseIndex > 16 && phaseIndex <= 22) return '🌖'; // Waning Gibbous
+    if (phaseIndex > 22 && phaseIndex <= 24) return '🌗'; // Last Quarter
+    if (phaseIndex > 24 && phaseIndex <= 29) return '🌘'; // Waning Crescent
+    if (phaseIndex > 29 && phaseIndex <= 31) return '🌑'; // New Moon
+  }
+
+  function getMoonPhaseName(phase) {
+    const phaseIndex = getPhaseIndex(phase);
+    if (phaseIndex > 0 && phaseIndex <= 1) return 'New Moon';
+    if (phaseIndex > 1 && phaseIndex <= 7) return 'Waxing Crescent';
+    if (phaseIndex === 8) return 'First Quarter';
+    if (phaseIndex > 8 && phaseIndex <= 14) return 'Waxing Gibbous';
+    if (phaseIndex > 14 && phaseIndex <= 16) return 'Full Moon';
+    if (phaseIndex > 16 && phaseIndex <= 23) return 'Waning Gibbous';
+    if (phaseIndex === 24) return 'Last Quarter';
+    if (phaseIndex > 24 && phaseIndex <= 29) return 'Waning Crescent';
+    if (phaseIndex > 29 && phaseIndex <= 31) return 'New Moon';
+  }
+
+  function displayPlanetInfoOnHover(event) {
+    // Get the target path element
+    const path = event.target;
+
+    // If the path's ID is '366-day', do not process further
+    if (path.id === '366-day') {
+      return;
+    }
+
+    // Extract the date information from the element's ID
+    const dateParts = path.id.split('-');
+    const dayOfYear = parseInt(dateParts[0]);
+    const dayOfMonth = parseInt(dateParts[1]);
+    const month = parseInt(dateParts[2]) - 1; // month is 0-indexed in JavaScript
+    const year = parseInt(dateParts[3]);
+    const date = new Date(year, month, dayOfMonth);
+
+
+    // displayDayInfo(date);
+    displayDayInfo(date, userLanguage, userTimeZone);
+
+
+    displayMoonPhaseInDiv(date);
+
+  // Check if the moon-cycle div is set to display block
+  // if (document.getElementById('moon-cycle').style.display === 'block') {
+  //   displayMoonPhaseInDiv(date);
+  // }
+
+  // Check if the venus-cycle div is set to display block
+  if (document.getElementById('venus-cycle').style.display === 'block') {
+    UpdateVenusData(date);
+  }
+
+  // Check if the mars-cycle div is set to display block
+  if (document.getElementById('mars-cycle').style.display === 'block') {
+    UpdateMarsData(date);
+  }
+
+  // Check if the jupiter-cycle div is set to display block
+  if (document.getElementById('jupiter-cycle').style.display === 'block') {
+    UpdateJupiterData(date);
+  }
+
+  // Check if the saturn-cycle div is set to display block
+  if (document.getElementById('saturn-cycle').style.display === 'block') {
+    UpdateSaturnData(date);
+  }
+}
+
+
+
+function displayMoonPhaseOnTouch(pathID) {
+  // Rest of your code to handle the touch event
+  const dateParts = pathID.split('-');
+  const dayOfYear = parseInt(dateParts[0]);
+  const dayOfMonth = parseInt(dateParts[1]);
+  const month = parseInt(dateParts[2]) - 1; // month is 0-indexed in JavaScript
+  const year = parseInt(dateParts[3]);
+  const date = new Date(year, month, dayOfMonth);
+  // Call the displayMoonPhaseInDiv function to show the moon phase details for the selected date
+  // Call the relevant functions to show details for the selected date
+  // displayDayInfo(date);
+  displayDayInfo(targetDate, userLanguage, userTimeZone);
+
+  displayMoonPhaseInDiv(date);
+
+
+  // // Check if the moon-cycle div is set to display block
+  // if (document.getElementById('moon-cycle').style.display === 'block') {
+  //   displayMoonPhaseInDiv(date);
+  // }
+
+  // Check if the venus-cycle div is set to display block
+  if (document.getElementById('venus-cycle').style.display === 'block') {
+    UpdateVenusData(date);
+  }
+
+  // Check if the mars-cycle div is set to display block
+  if (document.getElementById('mars-cycle').style.display === 'block') {
+    UpdateMarsData(date);
+  }
+
+  // Check if the jupiter-cycle div is set to display block
+  if (document.getElementById('jupiter-cycle').style.display === 'block') {
+    UpdateJupiterData(date);
+  }
+
+  // Check if the saturn-cycle div is set to display block
+  if (document.getElementById('saturn-cycle').style.display === 'block') {
+    UpdateSaturnData(date);
+  }
+}
+
+// This function displays the current moon phase after mouseout or touchout
+
+function redisplayTargetData() {
+  // Call the displayMoonPhaseInDiv function to show the moon phase details for the selected date
+  displayMoonPhaseInDiv(targetDate);
+  displayDayInfo(targetDate, userLanguage, userTimeZone);
+  UpdateVenusData(targetDate);
+
+}
+
+function handleTouchEnd() {
+  // Call the displayMoonPhaseInDiv function to show the moon phase details for the selected date
+  displayMoonPhaseInDiv(targetDate);
+  // displayDayInfo(targetDate);
+  // UpdateVenusData(targetDate);
+  //   console.log(targetDate);
+
+  //console.log(VenusElong);
+  // TODO: This function should call displayMoonPhaseInDiv() with the current date
+}
+
+
+function closeTheModal() {
+    const modal = document.getElementById('form-modal-message');
+
+    // Hide the modal
+    modal.classList.remove('modal-visible');
+    modal.classList.add('modal-hidden');
+    document.getElementById("page-content").classList.remove("blur");
+
+    modalOpen = false;
+
+    // Remove focus restriction
+    document.removeEventListener('focus', focusRestrict, true);
+}
+
+
+function focusRestrict(event) {
+    const modal = document.getElementById('form-modal-message');
+    if (modalOpen && !modal.contains(event.target)) {
+        event.stopPropagation(); // Prevent further propagation of the focus event
+        modal.focus();           // Redirect focus back to the modal
+    }
+}
+
+
+  /*----------MOON--------------------
+  // This function displays the moon phase details in the bottom right div element.
+*/
+
+  function displayMoonPhaseInDiv(date) {
+
+      // Check if the moon-cycle div is not set to display none
+      //NOTE:  this could be replaced and the prevention instead set on the displayPlanetInfoOnHover function
+  // var moonCycleDiv = document.getElementById('moon-cycle');
+  // if (moonCycleDiv.style.display === 'none') {
+  //   return; // Exit the function if moon-cycle is not displayed
+  // }
+
+    // Set the latitude and longitude to use for the moon phase calculations
+    const lat = -8.506853;
+    const lon = 115.262477;
+
+    // Calculate the moon illumination details and get the phase, emoji, and phase index
+    const moonIllumination = SunCalc.getMoonIllumination(date);
+    const phase = moonIllumination.phase;
+    const moonPhaseEmoji = getMoonPhaseEmoji(phase);
+    const phaseIndex = getPhaseIndex(phase);
+
+    // Calculate the moon position and get the distance, angle, illuminated fraction, and phase name
+    const moonPosition = SunCalc.getMoonPosition(date, lat, lon);
+    const moonDistance = moonPosition.distance.toFixed(2);
+    const moonAngle = (moonPosition.parallacticAngle * (180 / Math.PI)).toFixed(2);
+    const illuminatedFraction = moonIllumination.fraction.toFixed(2);
+    const moonPhaseName = getMoonPhaseName(phase);
+    //const islamicMonth = getIslamicMonth(date);
+    //const islamicMonthName = getIslamicMonthName(islamicMonth);
+    const maxMoonDist = 406700; // km
+    const minMoonDist = 363300; // km
+    const per_MoonDist = ((moonDistance - minMoonDist) / (maxMoonDist - minMoonDist)) * 100;
+    // Update the moon phase div with the calculated details
+    const moonPhaseDiv = document.getElementById('moon-phase');
+    const moonPhaseInfoDiv = document.getElementById('moon-info');
+
+    moonPhaseDiv.innerHTML = `${moonPhaseEmoji}`;
+    moonPhaseInfoDiv.innerHTML = `${moonPhaseName} <br>Illuminated Fraction: ${illuminatedFraction} <br>Angle: ${moonAngle}°<br>Distance: ${moonDistance} km<br>Percent of Max Distance: ${per_MoonDist.toFixed(0)} %`;
+
+    adjustMoonSize(per_MoonDist)
+  }
+
+
+
+  function adjustMoonSize(per_MoonDist) {
+    let minSize, maxSize;
+
+    if (window.innerWidth < 700) {
+      minSize = 1.3;
+      maxSize = 2;
+    } else {
+      minSize = 2.3;
+      maxSize = 3.2;
+     /* minSize = 3.7;
+      maxSize = 4.6;*/
+    }
+
+    const size = ((minSize - maxSize) * per_MoonDist / 100) + maxSize;
+    const moonPhase = document.getElementById("moon-phase");
+    moonPhase.style.fontSize = `${size.toFixed(2)}em`;
+    }
+
+
+  function addMoonPhaseInteraction() {
+    const dayPaths = document.querySelectorAll('path[id$="-day"]');
+    dayPaths.forEach((path) => {
+      path.addEventListener('mouseover', displayPlanetInfoOnHover);
+      path.addEventListener('mouseout', redisplayTargetData);
+
+    });
+  }
+
+  // Updates the Moon SVG display based on the phase index
+  function updateMoonPhaseDisplay(phaseIndex) {
+    for (let i = 0; i <= 30; i++) {
+      const moonPathElement = document.getElementById(`phase-${i}-moon`);
+      if (moonPathElement) {
+        moonPathElement.style.display = i <= phaseIndex ? 'inline' : 'none';
+      }
+    }
+  }
+
+  // Updates the Moon SVG display based on the moon phase for the given date
+  function updateMoonPhase(date) {
+    const moonPhase = SunCalc.getMoonIllumination(date).phase;
+    const phaseIndex = getPhaseIndex(moonPhase);
+
+    updateMoonPhaseDisplay(phaseIndex);
+
+    // Display debugging information
+    //displayDebugInfo(moonPhase, phaseIndex, `phase-${phaseIndex}-moon`);
+  }
+
+  // Resets the Moon phase path to the one that corresponds to the current date
+  function resetMoonPhase() {
+    // const currentDate = new Date();
+    updateMoonPhase(targetDate);
+  }
+
+  // Handles the event when a user hovers over a Sun path
+  function handleDayPathMouseOver(event) {
+    const dayPathId = event.target.id;
+    const [dayOfYear, day, month, year] = dayPathId.split('-').slice(0, 4);
+    const date = new Date(year, month - 1, day);
+
+    updateMoonPhase(date);
+  }
+
+ // Handles the event when a user touches a Day path
+function handleDayPathTouchStart(pathId) {
+  // Use the pathId parameter directly, as it is already the ID of the selected path
+  const [dayOfYear, day, month, year] = pathId.split('-').slice(0, 4);
+  const date = new Date(year, month - 1, day);
+
+  updateMoonPhase(date);
+}
+
+  // Handles the event when a user hovers off a Day path
+  function handleDayPathMouseOut(event) {
+    resetMoonPhase();
+  }
+
+    // Handles the event when a user hovers off a Day path
+    function handleDayPathTouchEnd(event) {
+      resetMoonPhase();
+    }
+
+
+
+
+
+    // DAY PATH LISTENING to Trigger all hover events
+
+    function addDayPathEventListeners() {
+      const earthCyclesSVG = document.getElementById('EarthCycles');
+
+      if (!earthCyclesSVG) {
+        console.error('EarthCycles SVG element not found');
+        return;
+      }
+
+      const dayPaths = earthCyclesSVG.querySelectorAll('path');
+
+      dayPaths.forEach((path) => {
+        if (path.id.endsWith('-day')) {
+          path.addEventListener('mouseover', handleDayPathMouseOver);
+          path.addEventListener('mouseout', handleDayPathMouseOut);
+          path.addEventListener('click', handleDayPathMouseOver);
+
+          // Add the touch event listeners to the path
+         // path.addEventListener('touchstart', handleDayPathTouchStart);
+          path.addEventListener('touchend', handleDayPathTouchEnd);
+          //path.addEventListener('touchcancel', handleDayPathTouchStart);
+        }
+      });
+    }
+
+document.addEventListener('svgLoaded', () => {
+  prevYear = document.getElementById('prev-year');
+  nextYear = document.getElementById('next-year');
+  const currentYearEl = document.getElementById('current-year');
+  currentYearText = currentYearEl ? currentYearEl.querySelector('tspan') : null;
+  weekPaths = document.querySelectorAll('path[id^="week-"]');
+
+  if (prevYear) prevYear.addEventListener('click', prevYearClick);
+  if (nextYear) nextYear.addEventListener('click', nextYearClick);
+
+  if (currentYearText) {
+    const currentYear = parseInt(currentYearText.textContent);
+    updateWeekTitles(currentYear);
+  }
+
+  addDayPathEventListeners();
+  resetMoonPhase();
+  addMoonPhaseInteraction();
+  displayCurrentMoonPhase();
+});
+
+
+
+
+
+
+
+
+
+

--- a/js/planet-orbits-2.js
+++ b/js/planet-orbits-2.js
@@ -1,0 +1,673 @@
+class Planet {
+  constructor(element_id, orbit_id, orbit_days) {
+    this.element_id = element_id; // ID of the SVG planet element
+    this.orbit_id = orbit_id; // ID of the SVG orbit element
+    this.orbit_days = orbit_days; // Number of days the planet takes to orbit
+  }
+
+  animate() {
+    const planetElement = document.getElementById(this.element_id);
+    const planetOrbitElement = document.getElementById(this.orbit_id);
+
+  if (!planetElement || !planetOrbitElement) {
+    console.warn(`Missing element for ${this.element_id} or ${this.orbit_id}`);
+    return;
+  }
+    // Reference date
+    const yearStart = new Date(2023, 0, 1);
+    //console.log("Initiating:" + yearStart + startDate);
+
+    // Calculate days and ratios
+    const daysSinceYearStart = Math.floor((startDate - yearStart) / (1000 * 60 * 60 * 24));
+    const daysSinceTargetDate = Math.floor((targetDate - startDate) / (1000 * 60 * 60 * 24));
+    const totalDays = daysSinceYearStart + daysSinceTargetDate;
+
+    const orbitRatio1 = daysSinceYearStart / this.orbit_days;
+    const orbitRatio2 = totalDays / this.orbit_days;
+
+    // Pre-calculate trigonometric values
+    const orbitRadius = planetOrbitElement.r.baseVal.value;
+    const finalCoords1 = {
+      x: orbitRadius * Math.sin(2 * Math.PI * orbitRatio1),
+      y: orbitRadius * Math.cos(2 * Math.PI * orbitRatio1),
+    };
+    const finalCoords2 = {
+      x: orbitRadius * Math.sin(2 * Math.PI * orbitRatio2),
+      y: orbitRadius * Math.cos(2 * Math.PI * orbitRatio2),
+    };
+
+    // GPU optimization with `will-change`
+    planetElement.style.willChange = "transform";
+
+    // Set the planet's position to the starting coordinates
+    if (startCoords.cx == 0 && startCoords.cy == 0) {
+      startCoords = {
+        cx: parseFloat(planetElement.getAttribute("cx") || 0),
+        cy: parseFloat(planetElement.getAttribute("cy") || 0),
+      };
+    }
+
+    planetElement.setAttribute("cx", startCoords.cx);
+    planetElement.setAttribute("cy", startCoords.cy);
+
+    // Create the first animation
+    const planetAnimation1 = planetElement.animate(
+      [
+        {
+          cx: startCoords.cx,
+          cy: startCoords.cy,
+          transform: `rotate(0deg)`,
+        },
+        {
+          cx: finalCoords1.x.toFixed(2) + "px",
+          cy: finalCoords1.y.toFixed(2) + "px",
+          transform: `rotate(${orbitRatio1 * 360}deg)`,
+        },
+      ],
+      {
+        duration: 0, // Immediate
+        easing: "linear",
+        fill: "forwards",
+      }
+    );
+
+    // Chain the second animation
+    planetAnimation1.onfinish = () => {
+      let animationDuration;
+      if (daysSinceTargetDate < 30) {
+        animationDuration = 500;
+      } else if (daysSinceTargetDate < 60) {
+        animationDuration = 1000;
+      } else if (daysSinceTargetDate < 120) {
+        animationDuration = 1500;
+      } else if (daysSinceTargetDate < 180) {
+        animationDuration = 2000;
+      } else if (daysSinceTargetDate <= 366) {
+        animationDuration = 3000;
+      } else {
+        animationDuration = 4000;
+      }
+
+      planetElement.animate(
+        [
+          {
+            cx: finalCoords1.x.toFixed(2) + "px",
+            cy: finalCoords1.y.toFixed(2) + "px",
+            transform: `rotate(${orbitRatio1 * 360}deg)`,
+          },
+          {
+            cx: finalCoords2.x.toFixed(2) + "px",
+            cy: finalCoords2.y.toFixed(2) + "px",
+            transform: `rotate(${orbitRatio2 * 360}deg)`,
+          },
+        ],
+        {
+          duration: animationDuration,
+          easing: "linear",
+          fill: "forwards",
+        }
+      );
+    };
+  }
+}
+
+// Create instances of the Planet class
+document.addEventListener('svgLoaded', () => {
+  const mercury = new Planet('mercury', 'mercury-orbit', 88);
+  const venus = new Planet('venus', 'venus-orbit', 224.7);
+  const earth = new Planet('earth', 'earth-orbit', 365);
+  const mars = new Planet('mars', 'mars-orbit', 687);
+  const jupiter = new Planet('jupiter', 'jupiter-orbit', 4333);
+  const saturn = new Planet('saturn', 'saturn-orbit', 10759);
+  const uranus = new Planet('uranus', 'uranus-orbit', 30687);
+  const neptune = new Planet('neptune', 'neptune-orbit', 60190);
+
+  mercury.animate();
+  venus.animate();
+  earth.animate();
+  mars.animate();
+  jupiter.animate();
+  saturn.animate();
+  uranus.animate();
+  neptune.animate();
+});
+
+
+/*----------------------------------
+
+
+PLANET DATA
+
+
+----------------------------------*/
+
+
+
+
+/*----------VENUS--------------------*/
+
+
+function UpdateVenusData(date) {
+
+  const now = date;
+
+  let VenusElong = Astronomy.Elongation('Venus', now);
+  let VenusIllum = Astronomy.Illumination('Venus', now);
+  let max_mag = -4.89;
+  let max_dist = 1.728;
+  let current_mag = VenusIllum.mag;
+  let current_dist = VenusIllum.geo_dist;
+  let per_dist = (current_dist / max_dist) * 100;
+  let magPercent = (current_mag / max_mag) * 100;
+
+
+  const elongation = VenusElong.elongation;
+  const illumination = VenusIllum.phase_fraction;
+  const distance = (max_dist / max_mag) * 100;
+
+  //  let VenusMag = Astronomy.SearchPeakMagnitude('Venus', now);
+  //  let VenusAngle = Astronomy.AngleFromSun('Venus', now);
+  //alert (VenusElong);
+  //alert("Venus:" + elongation);
+  //  let synodicPeriod = 584; // Venus synodic period in days
+
+  const illuminatedFraction = illumination.toFixed(2);
+  let VenusOpposition = Astronomy.SearchRelativeLongitude('Venus', 0, now);
+  const daysTilOpposition = daysBetweenDates(now, VenusOpposition.date);
+
+  // Determine Venus phase based on phase days
+
+  let phase;
+  let phaseDescription;
+
+  if (daysTilOpposition < 2) {
+    phase = '🌚';
+    phaseDescription = "in Opposition";
+    phaseSize = "100%";
+  }
+  if (daysTilOpposition >= 2 && daysTilOpposition < 5) {
+    phase = "🌑";
+    phaseDescription = "New";
+  }
+  if (daysTilOpposition >= 5 && daysTilOpposition < 18) {
+    phase = "🌒";
+    phaseDescription = "Waxing Crescent";
+
+  }
+  if (daysTilOpposition >= 18 && daysTilOpposition < 34) {
+    phase = "🌓";
+    phaseDescription = "1st Quarter";
+
+  }
+  if (daysTilOpposition >= 34 && daysTilOpposition < 36) {
+    phase = "🌓";
+    phaseDescription = "Max Elongation";
+  }
+  if (daysTilOpposition >= 36 && daysTilOpposition < 66) {
+    phase = "🌓";
+    phaseDescription = "2nd Quarter";
+  }
+  if (daysTilOpposition >= 66 && daysTilOpposition < 267) {
+    phase = "🌔";
+    phaseDescription = "3rd Quarter";
+  }
+  if (daysTilOpposition >= 267 && daysTilOpposition < 291) {
+    phase = "🌕";
+    phaseDescription = "conjunction";
+  }
+  if (daysTilOpposition >= 291 && daysTilOpposition < 293) {
+    phase = "🌚";
+    phaseDescription = "superior conjunction";
+  }
+  if (daysTilOpposition >= 293 && daysTilOpposition < 317) {
+    phase = "🌕";
+    phaseDescription = "hidden behind sun";
+  }
+  if (daysTilOpposition >= 317 && daysTilOpposition < 517) {
+    phase = "🌖";
+    phaseDescription = "remerging";
+  }
+  if (daysTilOpposition >= 517 && daysTilOpposition < 548) {
+    phase = "🌗";
+    phaseDescription = "4th Quarter";
+  }
+  if (daysTilOpposition >= 548 && daysTilOpposition < 550) {
+    phase = "🌗";
+    phaseDescription = "Max Elongation";
+  }
+  if (daysTilOpposition >= 550 && daysTilOpposition < 555) {
+    phase = "🌗";
+    phaseDescription = "Waning Crescent";
+  }
+  if (daysTilOpposition >= 555 && daysTilOpposition < 580) {
+    phase = "🌘";
+    phaseDescription = "Waning Crescent";
+  }
+  if (daysTilOpposition >= 580 && daysTilOpposition < 583) {
+    phase = "🌑";
+    phaseDescription = "New";
+  }
+  if (daysTilOpposition >= 583) {
+    phase = "🌚";
+    phaseDescription = "in Opposition";
+  }
+
+  document.getElementById("venus-phase").innerHTML = phase;
+
+  document.getElementById("venus-phase-info").innerHTML = "<span style=\"font-size:1.5em\">Venus ♀</span><br>" + phaseDescription + "@" + illuminatedFraction +
+    "<br>" + "Magnitude: " + VenusIllum.mag.toFixed(2) +
+    "<br>Days to Opposition: " +
+    daysTilOpposition.toFixed(0) +
+    "<br>Max Magnitude:" + magPercent.toFixed(0) +
+    '<br>Dist.:' + VenusIllum.geo_dist.toFixed(1) + ' AU (' + per_dist.toFixed(0) + '% of max)';
+
+  adjustVenusSize(per_dist);
+  adjustVenusPhaseMagnitude(magPercent);
+}
+
+/*Adjusts Venus icon size depending on how far away the planet is*/
+
+function adjustVenusSize(per_dist) {
+  let minSize, maxSize;
+
+  if (window.innerWidth < 700) {
+    minSize = 1.3;
+    maxSize = 2.0;
+  } else {
+    minSize = 3.2;
+    maxSize = 4.7;
+  }
+
+  const size = ((minSize - maxSize) * per_dist / 100) + maxSize;
+  const venusPhase = document.getElementById("venus-phase");
+  venusPhase.style.fontSize = `${size}em`;
+}
+
+/*Increases of decrease the brightness of the icon based on the planet's magnitude*/
+
+function adjustVenusPhaseMagnitude(magPercent, minOpacity = 0, maxOpacity = 1, sensitivity = 1) {
+  const opacity = minOpacity + (magPercent / 100) * (maxOpacity - minOpacity) * sensitivity; // calculate opacity based on magPercent and sensitivity
+  const emojiElement = document.getElementById("venus-phase");
+  emojiElement.style.opacity = opacity;
+}
+
+function daysBetweenDates(date1, date2) {
+  // Convert both dates to milliseconds
+  const date1Ms = date1.getTime();
+  const date2Ms = date2.getTime();
+  // Calculate the difference in milliseconds
+  const differenceMs = Math.abs(date1Ms - date2Ms);
+  // Convert the difference to days and return
+  return differenceMs / (1000 * 60 * 60 * 24);
+}
+
+
+/*MARS PLANET DATA*/
+
+function UpdateMarsData(date) {
+  const now = date;
+
+  let MarsElong = Astronomy.Elongation('Mars', now);
+  let MarsAngle = Astronomy.AngleFromSun('Mars', now);
+  let MarsIllum = Astronomy.Illumination('Mars', now);
+  let max_mag = -2.91;
+  let max_dist = 2.68;
+  let current_mag = MarsIllum.mag;
+  let current_dist = MarsIllum.geo_dist;
+  let per_dist = (current_dist / max_dist) * 100;
+  let magPercent = (current_mag / max_mag) * 100;
+
+  const marsElongation = MarsElong.elongation;
+  const illumination = MarsIllum.phase_fraction;
+  // const distance = (max_dist / max_mag) * 100;
+
+  const illuminatedFraction = illumination.toFixed(2);
+  let MarsOpposition = Astronomy.SearchRelativeLongitude('Mars', 0, now);
+  let synodicPeriod = 780; // Mars synodic period in days
+  const daysTilOpposition = daysBetweenDates(now, MarsOpposition.date);
+
+
+  // Determine Mars phase based on phase days
+  let phase;
+  let phaseDescription;
+
+  if (daysTilOpposition > 2) {
+    phase = "🌕";
+    phaseDescription = "Full";
+  }
+
+  if (daysTilOpposition <= 2 || daysTilOpposition >= 778) {
+    phase = '🌚';
+    phaseDescription = "In Opposition";
+    phaseSize = "100%";
+  }
+  if (daysTilOpposition >= 2 && daysTilOpposition < 5) {
+    phase = "🌑";
+    phaseDescription = "Nearing opposition";
+  }
+  if (marsElongation < 96 && marsElongation > 92) {
+    phase = '🌖';
+    phaseDescription = "at quadrature";
+    phaseSize = "90%";
+  }
+  if (marsElongation < 92 && marsElongation > 88) {
+    phase = '🌗';
+    phaseDescription = "at quadrature";
+    phaseSize = "90%";
+  }
+  if (marsElongation < 88 && marsElongation > 82) {
+    phase = '🌖';
+    phaseDescription = "at quadrature";
+    phaseSize = "90%";
+  }
+
+  if (marsElongation < 178 && marsElongation > 170) {
+    phase = '🌔';
+    phaseDescription = "at quadrature";
+    phaseSize = "90%";
+  }
+
+  if (marsElongation < 182 && marsElongation > 178) {
+    phase = '🌗';
+    phaseDescription = "at quadrature";
+    phaseSize = "90%";
+  }
+
+  if (marsElongation < 2) {
+    phase = '🌝';
+    phaseDescription = "at opposition";
+    phaseSize = "90%";
+  }
+
+  document.getElementById("mars-phase").innerHTML = phase;
+  document.getElementById("mars-phase-info").innerHTML =
+    "<span style=\"font-size:1.3em\">Mars ♂</span><br>" +
+    phaseDescription + "" +
+
+    "Magnitude: " +
+    MarsIllum.mag.toFixed(2) +
+    // "<br>Percent of Max Magnitude: " +
+    // magPercent.toFixed(2) +
+    "<br>Elongation: " +
+    marsElongation.toFixed(1) +
+    "°<br>Days to Opposition: " +
+    daysTilOpposition.toFixed(0) +
+    "<br>Illuminated fraction: " +
+    illuminatedFraction +
+    "<br>Dist: " +
+    MarsIllum.geo_dist.toFixed(1) +
+    " AU (" +
+    per_dist.toFixed(0) +
+    "% of max)";
+
+  adjustMarsSize(per_dist);
+}
+
+function adjustMarsSize(per_dist) {
+  let minSize, maxSize;
+
+  if (window.innerWidth < 700) {
+    minSize = 1.3;
+    maxSize = 2.0;
+  } else {
+    minSize = 3.2;
+    maxSize = 4.7;
+  }
+
+  const size = ((minSize - maxSize) * per_dist / 100) + maxSize;
+  const marsPhase = document.getElementById("mars-phase");
+  marsPhase.style.fontSize = `${size}em`;
+}
+
+function adjustMarsPhaseMagnitude(
+  magPercent,
+  minOpacity = 0,
+  maxOpacity = 1,
+  sensitivity = 1
+) {
+  const opacity =
+    minOpacity +
+    (magPercent / 100) * (maxOpacity - minOpacity) * sensitivity; // calculate opacity based on magPercent and sensitivity
+  const emojiElement = document.getElementById("mars-phase");
+  emojiElement.style.opacity = opacity;
+}
+
+
+/*JUPITER PLANET DATA*/
+
+function UpdateJupiterData(date) {
+  const now = date;
+
+  let JupiterElong = Astronomy.Elongation('Jupiter', now);
+  let JupiterAngle = Astronomy.AngleFromSun('Jupiter', now);
+  let JupiterIllum = Astronomy.Illumination('Jupiter', now);
+  let max_mag = -2.9;
+  let max_dist = 6.9;
+  let min_dist = 4.0;
+  let current_mag = JupiterIllum.mag;
+  let current_dist = JupiterIllum.geo_dist;
+  let per_dist = ((current_dist - min_dist) / (max_dist - min_dist)) * 100;
+  let magPercent = (current_mag / max_mag) * 100;
+
+  const jupiterElongation = JupiterElong.elongation;
+  const illumination = JupiterIllum.phase_fraction;
+  // const distance = (max_dist / max_mag) * 100;
+
+  const illuminatedFraction = illumination.toFixed(2);
+  let JupiterOpposition = Astronomy.SearchRelativeLongitude('Jupiter', 0, now);
+  let synodicPeriod = 398.88; // Jupiter synodic period in days
+  const daysTilOpposition = daysBetweenDates(now, JupiterOpposition.date);
+
+
+  // Determine Jupiter phase based on phase days
+  let phase = "🌕";
+  let phaseDescription = "Jupiter ♃";
+  /*
+    if  (daysTilOpposition > 2) {
+      phase = "🌕";
+      phaseDescription = "<span style=\"font-size:1.3em\">♄ Jupiter</span>";
+    }
+
+    if (daysTilOpposition <= 2 || daysTilOpposition >= 778) {
+      phase = '🌚';
+      phaseDescription = "Saturn is in Opposition";
+    }
+    if (daysTilOpposition >= 2 && daysTilOpposition < 5) {
+      phase = "🌑";
+      phaseDescription = "Saturn cannot be seen as it approaches opposition";
+    }
+
+  */
+
+
+  document.getElementById("jupiter-phase").innerHTML = phase;
+  document.getElementById("jupiter-phase-info").innerHTML =
+    "<span style=\"font-size:1.5em\">" + phaseDescription + "</span><br>Magnitude:" +
+    JupiterIllum.mag.toFixed(1) +
+    // "<br>Percent of Max Magnitude: " +
+    // magPercent.toFixed(2) +
+    "<br>Elongation: " +
+    jupiterElongation.toFixed(1) +
+    "°<br>Days to Opposition: " +
+    daysTilOpposition.toFixed(0) +
+    // "<br>Illuminated fraction: " +
+    // illuminatedFraction +
+    "<br>Dist.: " +
+    JupiterIllum.geo_dist.toFixed(1) +
+    "AU (" +
+    per_dist.toFixed(0) +
+    "% of max)";
+
+  adjustJupiterSize(per_dist);
+}
+
+function adjustJupiterSize(per_dist) {
+  let minSize, maxSize;
+
+  if (window.innerWidth < 700) {
+    minSize = 1.3;
+    maxSize = 2.0;
+  } else {
+    minSize = 2;
+    maxSize = 4;
+  }
+
+  const size = ((minSize - maxSize) * per_dist / 100) + maxSize;
+  const marsPhase = document.getElementById("jupiter-phase");
+  marsPhase.style.fontSize = `${size}em`;
+}
+
+
+
+
+/*SATURN PLANET DATA*/
+
+function UpdateSaturnData(date) {
+  const now = date;
+
+  let SaturnElong = Astronomy.Elongation('Saturn', now);
+  let SaturnAngle = Astronomy.AngleFromSun('Saturn', now);
+  let SaturnIllum = Astronomy.Illumination('Saturn', now);
+  let max_mag = -0.2;
+  let max_dist = 11.36;
+  let min_dist = 8.03;
+  let current_mag = SaturnIllum.mag;
+  let current_dist = SaturnIllum.geo_dist;
+  let per_dist = ((current_dist - min_dist) / (max_dist - min_dist)) * 100;
+  let magPercent = (current_mag / max_mag) * 100;
+
+  const saturnElongation = SaturnElong.elongation;
+  const illumination = SaturnIllum.phase_fraction;
+  // const distance = (max_dist / max_mag) * 100;
+
+  const illuminatedFraction = illumination.toFixed(2);
+  let SaturnOpposition = Astronomy.SearchRelativeLongitude('Saturn', 0, now);
+  let synodicPeriod = 378; // Saturn synodic period in days
+  const daysTilOpposition = daysBetweenDates(now, SaturnOpposition.date);
+
+
+  // Determine Saturn phase based on phase days
+  let phase = "🪐";
+  let phaseDescription = "Saturn ♄";
+  /*
+    if  (daysTilOpposition > 2) {
+      phase = "🌕";
+      phaseDescription = "<span style=\"font-size:1.3em\">♄ Saturn</span>";
+    }
+
+    if (daysTilOpposition <= 2 || daysTilOpposition >= 778) {
+      phase = '🌚';
+      phaseDescription = "Saturn is in Opposition";
+    }
+    if (daysTilOpposition >= 2 && daysTilOpposition < 5) {
+      phase = "🌑";
+      phaseDescription = "Saturn cannot be seen as it approaches opposition";
+    }
+
+  */
+
+
+  document.getElementById("saturn-phase").innerHTML = phase;
+  document.getElementById("saturn-phase-info").innerHTML =
+    "<span style=\"font-size:1.5em\">" + phaseDescription + "</span><br>Magnitude: " +
+    SaturnIllum.mag.toFixed(1) +
+    // "<br>Percent of Max Magnitude: " +
+    // magPercent.toFixed(2) +
+    "<br>Elongation: " +
+    saturnElongation.toFixed(1) +
+    "°<br>Days to Opposition: " +
+    daysTilOpposition.toFixed(0) +
+    //  "<br>Illuminated fraction: " +
+    // illuminatedFraction +
+    "<br>Distance: " +
+    SaturnIllum.geo_dist.toFixed(1) +
+    " AU" +
+    "<br>Max Distance: " +
+    per_dist.toFixed(0) + "%";
+
+  adjustSaturnSize(per_dist);
+}
+
+function adjustSaturnSize(per_dist) {
+  let minSize, maxSize;
+
+  if (window.innerWidth < 700) {
+    minSize = 1.3;
+    maxSize = 2.0;
+  } else {
+    minSize = 2;
+    maxSize = 5;
+  }
+
+  const size = ((minSize - maxSize) * per_dist / 100) + maxSize;
+  const marsPhase = document.getElementById("saturn-phase");
+  marsPhase.style.fontSize = `${size}em`;
+}
+
+
+
+
+document.addEventListener("DOMContentLoaded", () => {
+
+
+document.getElementById("mercury").addEventListener("click", () => {
+  console.log("Mercury clicked - No update function defined yet.");
+});
+
+document.getElementById("venus").addEventListener("click", () => {
+  UpdateVenusData(targetDate);
+});
+
+document.getElementById("earth").addEventListener("click", () => {
+  console.log("Earth clicked - No update function defined yet.");
+});
+
+document.getElementById("mars").addEventListener("click", () => {
+  UpdateMarsData(targetDate);
+});
+
+document.getElementById("jupiter").addEventListener("click", () => {
+  UpdateJupiterData(targetDate);
+});
+
+document.getElementById("saturn").addEventListener("click", () => {
+  UpdateSaturnData(targetDate);
+});
+
+document.getElementById("uranus").addEventListener("click", () => {
+  console.log("Uranus clicked - No update function defined yet.");
+});
+
+document.getElementById("neptune").addEventListener("click", () => {
+  console.log("Neptune clicked - No update function defined yet.");
+});
+
+});
+
+
+function arePlanetsReady() {
+  const ids = [
+    "mercury", "venus", "earth", "mars", "jupiter", "saturn", "uranus", "neptune",
+    "mercury-orbit", "venus-orbit", "earth-orbit", "mars-orbit", "jupiter-orbit",
+    "saturn-orbit", "uranus-orbit", "neptune-orbit"
+  ];
+  return ids.every(id => document.getElementById(id) !== null);
+}
+
+function animatePlanetsIfReady(retries = 10) {
+  if (arePlanetsReady()) {
+    mercury.animate();
+    venus.animate();
+    earth.animate();
+    mars.animate();
+    jupiter.animate();
+    saturn.animate();
+    uranus.animate();
+    neptune.animate();
+  } else if (retries > 0) {
+    console.warn("Planet elements not ready. Retrying...");
+    setTimeout(() => animatePlanetsIfReady(retries - 1), 300);
+  } else {
+    console.error("Planet elements still missing after multiple retries.");
+  }
+}


### PR DESCRIPTION
## Summary
- Duplicate calendar JS files with -2 suffix and delay initialization until the injected SVG is available
- Dispatch custom `svgLoaded` event after dynamically loading the calendar SVG
- Update dash-2.html to use the new files and wait for SVG load

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e216cc0c4832bac08ce3a911847f2