### PR TITLE
Use updated scripts and defer calendar-dependent setup

### DIFF
--- a/dash-2.html
+++ b/dash-2.html
@@ -1378,26 +1378,29 @@
     // Get all SVG elements containing paths with id*="-day"
     //const currentElements = svg.querySelectorAll("path[id*='-day'], g[id*='-day']");
 
-    const svgElements = document.querySelectorAll("svg");
     const paths = [];
 
     let selectedPath = null; // Track the currently selected path
 
-    svgElements.forEach((svg) => {
-        // Get the paths in the current SVG that have '-day' in their ID
-        const currentPaths = svg.querySelectorAll("path[id*='-day']");
-        paths.push(...currentPaths);
+    document.addEventListener('svgLoaded', () => {
+        const svgElements = document.querySelectorAll("svg");
 
-        currentPaths.forEach((path) => {
-            // Add click and touch event listeners to each path
-            path.addEventListener("click", function () {
-                resetPaths(); // Reset all paths to their default state
-                this.classList.add("active", "final");
-                selectedPath = this; // Set this path as the selected path
+        svgElements.forEach((svg) => {
+            // Get the paths in the current SVG that have '-day' in their ID
+            const currentPaths = svg.querySelectorAll("path[id*='-day']");
+            paths.push(...currentPaths);
+
+            currentPaths.forEach((path) => {
+                // Add click and touch event listeners to each path
+                path.addEventListener("click", function () {
+                    resetPaths(); // Reset all paths to their default state
+                    this.classList.add("active", "final");
+                    selectedPath = this; // Set this path as the selected path
+                });
+                path.addEventListener("touchstart", onTouch, false);
+                path.addEventListener("touchmove", onTouch, false);
+                path.addEventListener("touchend", onTouchEnd, false);
             });
-            path.addEventListener("touchstart", onTouch, false);
-            path.addEventListener("touchmove", onTouch, false);
-            path.addEventListener("touchend", onTouchEnd, false);
         });
     });
 
@@ -1511,9 +1514,9 @@
 
 
 
-<script src="js/1-event-management.js?v=2"></script>
+<script src="js/1-event-management-2.js"></script>
 <script src="js/calendar-scripts-2.js"></script>
-<script src="js/kin-cycles.js"></script>
+<script src="js/kin-cycles-2.js"></script>
 
 
 


### PR DESCRIPTION
## Summary
- switch dashboard to use new event management and kin cycles scripts
- defer touch interaction setup until calendar SVG is loaded

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_688e2a8a8654832bb10bdc9273df1904