### PR TITLE
Set default language from browser when user not logged in

### DIFF
--- a/js/login-scripts.js
+++ b/js/login-scripts.js
@@ -254,16 +254,15 @@ document.addEventListener("DOMContentLoaded", async () => {
 
 
 function useDefaultUser() {
-    let userLanguage = navigator.language ? navigator.language.slice(0, 2) : 'en';
+    userLanguage = (navigator.language || 'en').slice(0, 2);
 
-    let userTimeZone;
     try {
         userTimeZone = Intl.DateTimeFormat().resolvedOptions().timeZone || "Asia/Jakarta";
     } catch (e) {
         userTimeZone = "Asia/Jakarta"; // fallback if browser doesn't support timeZone
     }
 
-    const userProfile = {
+    userProfile = {
         first_name: "Earthling",
         earthling_emoji: "🐸",
         email: null,


### PR DESCRIPTION
## Summary
- Fix ReferenceError when no user is logged in by defining global `userLanguage`
- Detect browser language for guests and fall back to English if unavailable
- Ensure `userTimeZone` and `userProfile` are globally assigned for guest users

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689214802e94832b84ceed34fcbde23f