### PR TITLE
Fix script loading order for calendar

### DIFF
--- a/dash.html
+++ b/dash.html
@@ -144,20 +144,6 @@
     <!-- Functional orbital calculations-->
     <!--<script src="https://cdn.jsdelivr.net/npm/hijri-js@1.0.25/dist/hijri-js.common.min.js"></script>-->
     <script src="js/hijri-js.common.min.js"></script>
-    <script src="js/core-javascripts.js?v=2"></script>
-    <!--functional scripts-->
-    <script src="js/breakouts-2.js"></script>
-    <!--breakout control scripts-->
-    <script src="js/set-targetdate.js"></script>
-    <!--functional scripts-->
-    <script src="js/1-lunar-scripts.js"></script>
-    <!-- concerning the moon-->
-    <script src="js/planet-orbits-2.js"></script>
-    <!--planets-->
-    <script src="js/login-scripts.js"></script>
-    <!--planets-->
-    <script src="js/time-setting.js"></script>
-    <!--setting user time, timezone, clock-->
 
     <!--Default Light Styles to load first-->
     <link
@@ -2200,8 +2186,15 @@
       );
     });
   </script>
-  <!-- Load event management, calendar logic, and kin cycle scripts -->
-  <script src="js/1-event-management-2.js"></script>
-  <script src="js/calendar-scripts-2.js"></script>
-  <script src="js/kin-cycles-2.js"></script>
+  <!-- Load functional scripts after the page content -->
+  <script src="js/planet-orbits-2.js" defer></script>
+  <script src="js/core-javascripts.js?v=2" defer></script>
+  <script src="js/breakouts-2.js" defer></script>
+  <script src="js/set-targetdate.js" defer></script>
+  <script src="js/1-lunar-scripts.js" defer></script>
+  <script src="js/login-scripts.js" defer></script>
+  <script src="js/time-setting.js" defer></script>
+  <script src="js/1-event-management-2.js" defer></script>
+  <script src="js/calendar-scripts-2.js" defer></script>
+  <script src="js/kin-cycles-2.js" defer></script>
 </html>


### PR DESCRIPTION
## Summary
- defer functional scripts and load planet-orbits before calendar logic
- ensure calendar page loads planet data to avoid missing function errors

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6892f9cf6fac832bbbd27b762b95e1e1