### PR TITLE
Guard planet data updates against missing scripts

### DIFF
--- a/js/core-javascripts.js
+++ b/js/core-javascripts.js
@@ -13,6 +13,35 @@ let dayOfYear;
 let timezone;
 let language;
 
+// Ensure planet-orbits script is present before invoking planet data updates
+function ensurePlanetData(date) {
+  if (typeof UpdateVenusData === "function") {
+    UpdateVenusData(date);
+    if (typeof UpdateMarsData === "function") {
+      UpdateMarsData(date);
+    }
+    if (typeof UpdateJupiterData === "function") {
+      UpdateJupiterData(date);
+    }
+    if (typeof UpdateSaturnData === "function") {
+      UpdateSaturnData(date);
+    }
+    return;
+  }
+
+  let script = document.getElementById("planet-orbits-loader");
+  if (!script) {
+    script = document.createElement("script");
+    script.id = "planet-orbits-loader";
+    script.src = "js/planet-orbits-2.js";
+    script.defer = true;
+    script.onload = () => ensurePlanetData(date);
+    document.head.appendChild(script);
+  } else {
+    script.addEventListener("load", () => ensurePlanetData(date), { once: true });
+  }
+}
+
 
 
 
@@ -466,17 +495,14 @@ function getTheDayOfYear(targetDate) {
     currentYearText.textContent = targetDate.getFullYear().toString();
     const currentYear = parseInt(currentYearText.textContent);
 
-    setLunarMonthForTarget(targetDate, currentYear);
+   setLunarMonthForTarget(targetDate, currentYear);
 
    setTimeout(function() {
     displayMoonPhaseInDiv(targetDate);
 
     displayMoonPhaseInDiv(targetDate);
 
-    UpdateVenusData(targetDate);
-    UpdateMarsData(targetDate);
-    UpdateJupiterData(targetDate);
-    UpdateSaturnData(targetDate);
+    ensurePlanetData(targetDate);
 
     // redisplayTargetData();
     startDate = targetDate;


### PR DESCRIPTION
## Summary
- Dynamically load `planet-orbits-2.js` when planet update functions are missing, then re-run the update routines
- Invoke planetary update functions only when they exist to avoid runtime errors
- Revert script order changes in legacy HTML files so the PR only alters `core-javascripts.js`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68993b37522c832b8d26ef5820be7c0d