### PR TITLE
Ensure planets animate after dates load

### DIFF
--- a/dash.html
+++ b/dash.html
@@ -483,6 +483,8 @@
 
       /*ROLL CALL*/
       window.onload = async function () {
+        // Ensure dates exist before SVG load dispatches 'svgLoaded'
+        setCurrentDate();
         await loadCalendarSvg();
 
         const solarCenterDiv = document.getElementById("solar-system-center");
@@ -535,8 +537,6 @@
           };
 
           prefillAddDateCycle(cycleData);
-        } else {
-          setCurrentDate(); // Fallback if no shared event
         }
 
         const currentYear = parseInt(currentYearText.textContent); //gets the year from the currentYearText div
@@ -562,11 +562,9 @@
         // UpdateJupiterData(targetDate);
         // UpdateSaturnData(targetDate);
 
-        if (typeof animatePlanetsIfReady === "function") {
-          setTimeout(animatePlanetsIfReady, 1500);
-        } else {
-          console.warn("animatePlanetsIfReady is not defined");
-        }
+        planetsReady.then(() => {
+          calendarRefresh();
+        });
 
         setTimeout(function () {
           startDate = targetDate;

--- a/js/planet-orbits-2.js
+++ b/js/planet-orbits-2.js
@@ -117,6 +117,12 @@ class Planet {
 // with matching IDs, causing `Element.animate` errors when invoked without arguments.
 let mercury, venus, earth, mars, jupiter, saturn, uranus, neptune;
 
+// Promise that resolves when planet instances are ready
+let planetsReadyResolve;
+const planetsReady = new Promise((resolve) => {
+  planetsReadyResolve = resolve;
+});
+
 // Create instances of the Planet class once the calendar SVG is loaded
 document.addEventListener('svgLoaded', () => {
   mercury = new Planet('mercury', 'mercury-orbit', 88);
@@ -128,15 +134,7 @@ document.addEventListener('svgLoaded', () => {
   uranus  = new Planet('uranus',  'uranus-orbit',  30687);
   neptune = new Planet('neptune', 'neptune-orbit', 60190);
 
-  // Kick off initial animations now that the elements exist
-  mercury.animate();
-  venus.animate();
-  earth.animate();
-  mars.animate();
-  jupiter.animate();
-  saturn.animate();
-  uranus.animate();
-  neptune.animate();
+  planetsReadyResolve();
 });
 
 


### PR DESCRIPTION
## Summary
- Set current date before loading SVG so `startDate` and `targetDate` exist when `svgLoaded` fires
- Introduce a `planetsReady` promise resolved when planet instances are created
- Trigger initial animation through `planetsReady.then(calendarRefresh)` instead of direct `planet.animate()` calls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a0599f9f20832b82b736ebbe941ef2