### PR TITLE
Handle missing planetsReady

### DIFF
--- a/dash.html
+++ b/dash.html
@@ -562,9 +562,16 @@
         // UpdateJupiterData(targetDate);
         // UpdateSaturnData(targetDate);
 
-        planetsReady.then(() => {
+        // Refresh the calendar once planetary orbits are initialised. If the
+        // orbital script fails to load for any reason, fall back to an
+        // immediate refresh so the page still functions.
+        if (window.planetsReady) {
+          window.planetsReady.then(() => {
+            calendarRefresh();
+          });
+        } else {
           calendarRefresh();
-        });
+        }
 
         setTimeout(function () {
           startDate = targetDate;

--- a/js/planet-orbits-2.js
+++ b/js/planet-orbits-2.js
@@ -122,6 +122,10 @@ let planetsReadyResolve;
 const planetsReady = new Promise((resolve) => {
   planetsReadyResolve = resolve;
 });
+// Expose the promise on the global object so other scripts can safely
+// reference it without causing a ReferenceError when this file hasn't been
+// loaded yet.
+window.planetsReady = planetsReady;
 
 // Create instances of the Planet class once the calendar SVG is loaded
 document.addEventListener('svgLoaded', () => {


### PR DESCRIPTION
## Summary
- expose `planetsReady` promise globally so other scripts can reliably wait for planet orbit initialisation
- guard calendar refresh call against missing `planetsReady` to avoid load-time ReferenceErrors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a07642106c832b82ff891102df7c12