### PR TITLE
Fix lunar script load order

### DIFF
--- a/js/1-lunar-scripts.js
+++ b/js/1-lunar-scripts.js
@@ -289,13 +289,6 @@ function adjustMoonSize(per_MoonDist) {
 
 
 
-// Initialize the event listeners and display the current Moon phase
-addMoonPhaseInteraction();
-displayCurrentMoonPhase();
-//displayMoonPhaseOnTouch();
-//handleTouchEnd();
-
-
 // This function displays the current moon phase NEEDED
 function displayCurrentMoonPhase() {
 const currentDate = targetDate;
@@ -306,6 +299,10 @@ const currentDate = targetDate;
 
 
 
+
+function displayMoonPhaseOnHover(event) {
+  handleDayPathMouseOver(event);
+}
 
 function addMoonPhaseInteraction() {
   const dayPaths = document.querySelectorAll('path[id$="-day"]');
@@ -372,6 +369,11 @@ function handleDayPathMouseOut(event) {
   function handleDayPathTouchEnd(event) {
     resetMoonPhase();
   }
+
+addMoonPhaseInteraction();
+displayCurrentMoonPhase();
+//displayMoonPhaseOnTouch();
+//handleTouchEnd();
 
 
 

--- a/js/init-calendar.js
+++ b/js/init-calendar.js
@@ -86,4 +86,4 @@ async function init() {
   }
 }
 
-init();
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- Delay calendar initialization until DOMContentLoaded to ensure SVG and assets load in order
- Add moon hover handler and defer moon phase setup until after functions load to avoid ReferenceError

## Testing
- `npm test` *(fails: npm: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a534279c78832baf62f7fa0de0296e