### PR TITLE
Fix undefined redisplayTargetData in lunar scripts

### DIFF
--- a/js/init-calendar.js
+++ b/js/init-calendar.js
@@ -53,12 +53,12 @@ async function init() {
       'js/core-javascripts.js?v=2',
       'js/breakouts.js',
       'js/set-targetdate.js',
-      'js/1-lunar-scripts.js',
       'js/planet-orbits.js',
       'js/login-scripts.js',
       'js/time-setting.js',
       'js/1-event-management.js?v=2',
       'js/calendar-scripts.js',
+      'js/1-lunar-scripts.js',
       'js/kin-cycles.js',
       'js/dark-mode-toggle.mjs.js'
     ];


### PR DESCRIPTION
## Summary
- Load `1-lunar-scripts.js` after `calendar-scripts.js` to ensure shared functions like `redisplayTargetData` are available.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5a3db1cf0832b8593f78b50f94ed4