### PR TITLE
Default dates for Planet animations

### DIFF
--- a/js/planet-orbits-dec28.js
+++ b/js/planet-orbits-dec28.js
@@ -15,21 +15,36 @@ class Planet {
   }
 
   // Define the animate method to move the planet along its orbit
-  animate() {
+  animate(startDate, targetDate) {
+    const start =
+      startDate instanceof Date && !isNaN(startDate.getTime())
+        ? startDate
+        : new Date();
+    const target =
+      targetDate instanceof Date && !isNaN(targetDate.getTime())
+        ? targetDate
+        : new Date();
+
     // Get the SVG elements for the planet and its orbit using their IDs
     let planetElement = document.getElementById(this.element_id);
     let planetOrbitElement = document.getElementById(this.orbit_id);
+
+    if (!planetElement || !planetOrbitElement) {
+      console.warn(`Missing element for ${this.element_id} or ${this.orbit_id}`);
+      return;
+    }
+
     // Set a reference date of January 1, 2023 - WHAT?  why isn't this 2024 now that the vector positions are updated?
 
     let yearStart = new Date(2023, 0, 1);
-     //console.log("Initiating:"+ yearStart + startDate);
+     //console.log("Initiating:"+ yearStart + start);
 
     let planetAnimation2;
 
     // Calculate the number of days since the reference date 'yearStart'
-    let daysSinceYearStart = Math.floor((startDate - yearStart) / (1000 * 60 * 60 * 24));
-    // Calculate the number of days from the 'startDate' to the 'targetDate'
-    let daysSinceTargetDate = Math.floor((targetDate - startDate) / (1000 * 60 * 60 * 24));
+    let daysSinceYearStart = Math.floor((start - yearStart) / (1000 * 60 * 60 * 24));
+    // Calculate the number of days from the 'start' to the 'target'
+    let daysSinceTargetDate = Math.floor((target - start) / (1000 * 60 * 60 * 24));
     // Sum the two durations to get the total days
     let totalDays = daysSinceYearStart + daysSinceTargetDate;
 

--- a/js/planet-orbits.js
+++ b/js/planet-orbits.js
@@ -5,21 +5,30 @@ class Planet {
     this.orbit_days = orbit_days; // Number of days the planet takes to orbit
   }
 
-  animate() {
+  animate(startDate, targetDate) {
+    const start =
+      startDate instanceof Date && !isNaN(startDate.getTime())
+        ? startDate
+        : new Date();
+    const target =
+      targetDate instanceof Date && !isNaN(targetDate.getTime())
+        ? targetDate
+        : new Date();
+
     const planetElement = document.getElementById(this.element_id);
     const planetOrbitElement = document.getElementById(this.orbit_id);
 
-  if (!planetElement || !planetOrbitElement) {
-    console.warn(`Missing element for ${this.element_id} or ${this.orbit_id}`);
-    return;
-  }
+    if (!planetElement || !planetOrbitElement) {
+      console.warn(`Missing element for ${this.element_id} or ${this.orbit_id}`);
+      return;
+    }
     // Reference date
     const yearStart = new Date(2023, 0, 1);
-    //console.log("Initiating:" + yearStart + startDate);
+    //console.log("Initiating:" + yearStart + start);
 
     // Calculate days and ratios
-    const daysSinceYearStart = Math.floor((startDate - yearStart) / (1000 * 60 * 60 * 24));
-    const daysSinceTargetDate = Math.floor((targetDate - startDate) / (1000 * 60 * 60 * 24));
+    const daysSinceYearStart = Math.floor((start - yearStart) / (1000 * 60 * 60 * 24));
+    const daysSinceTargetDate = Math.floor((target - start) / (1000 * 60 * 60 * 24));
     const totalDays = daysSinceYearStart + daysSinceTargetDate;
 
     const orbitRatio1 = daysSinceYearStart / this.orbit_days;
@@ -121,6 +130,13 @@ const saturn = new Planet("saturn", "saturn-orbit", 10759);
 const uranus = new Planet("uranus", "uranus-orbit", 30687);
 const neptune = new Planet("neptune", "neptune-orbit", 60190);
 
+
+if (!(startDate instanceof Date) || isNaN(startDate.getTime())) {
+  startDate = new Date();
+}
+if (!(targetDate instanceof Date) || isNaN(targetDate.getTime())) {
+  targetDate = new Date();
+}
 
 mercury.animate(startDate, targetDate);
 venus.animate(startDate, targetDate);


### PR DESCRIPTION
## Summary
- Ensure start and target dates are valid before triggering planet animations.
- Safeguard Planet.animate by defaulting missing dates to the current date.

## Testing
- `npm test`
- `node` (planet-orbits.js executed with undefined dates)


------
https://chatgpt.com/codex/tasks/task_e_68a6042f94ec832b9472df514a3c3d41