### PR TITLE
fix: preload lunar helpers before calendar scripts

### DIFF
--- a/js/1-lunar-scripts.js
+++ b/js/1-lunar-scripts.js
@@ -289,10 +289,25 @@ function adjustMoonSize(per_MoonDist) {
 
 
 
-// This function displays the current moon phase NEEDED
+// Displays the Moon phase for the globally selected target date.
+//
+// The function defers to other helpers if they are available so it can be
+// safely executed even if some dependencies have not yet been loaded. This is
+// useful because 1-lunar-scripts.js is loaded before calendar-scripts.js where
+// `displayMoonPhaseInDiv` is defined.
 function displayCurrentMoonPhase() {
-const currentDate = targetDate;
-// TODO: This function should call displayMoonPhaseInDiv() with the current date
+  const currentDate = typeof targetDate !== "undefined" ? targetDate : new Date();
+
+  // Update the textual/emoji representation of the Moon phase if the helper
+  // exists.
+  if (typeof displayMoonPhaseInDiv === "function") {
+    displayMoonPhaseInDiv(currentDate);
+  }
+
+  // Update the SVG representation of the Moon phase if the helper exists.
+  if (typeof updateMoonPhase === "function") {
+    updateMoonPhase(currentDate);
+  }
 }
 
 
@@ -370,8 +385,10 @@ function handleDayPathMouseOut(event) {
     resetMoonPhase();
   }
 
-addMoonPhaseInteraction();
-displayCurrentMoonPhase();
+// Initialization moved to calendar-scripts.js to ensure dependencies are
+// available when these functions are executed.
+//addMoonPhaseInteraction();
+//displayCurrentMoonPhase();
 //displayMoonPhaseOnTouch();
 //handleTouchEnd();
 

--- a/js/init-calendar.js
+++ b/js/init-calendar.js
@@ -57,8 +57,8 @@ async function init() {
       'js/login-scripts.js',
       'js/time-setting.js',
       'js/1-event-management.js?v=2',
+      'js/1-lunar-scripts.js', // defines displayCurrentMoonPhase before calendar-scripts.js
       'js/calendar-scripts.js',
-      'js/1-lunar-scripts.js',
       'js/kin-cycles.js',
       'js/dark-mode-toggle.mjs.js'
     ];


### PR DESCRIPTION
## Summary
- implement robust `displayCurrentMoonPhase` helper
- ensure lunar script loads before calendar scripts

## Testing
- `node -e "global.targetDate=new Date(); global.displayMoonPhaseInDiv=()=>{}; eval(require('fs').readFileSync('js/1-lunar-scripts.js','utf8')); global.updateMoonPhase=()=>{}; displayCurrentMoonPhase(); console.log('done');"`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a6868d9a44832bb40d6d6b3b929552