### PR TITLE
Fix push2today login check with session storage

### DIFF
--- a/js/1-event-management.js
+++ b/js/1-event-management.js
@@ -1161,8 +1161,12 @@ function push2today(uniqueKey) {
                 dateCycle.synced = "0";
             }
 
-            // Attempt to update the server immediately if online.
-            if (navigator.onLine && localStorage.getItem('buwana_id')) {
+            // Attempt to update the server immediately if online and logged in.
+            const buwanaId =
+                JSON.parse(sessionStorage.getItem('buwana_user') || '{}').buwana_id ||
+                localStorage.getItem('buwana_id');
+
+            if (navigator.onLine && buwanaId) {
                 updateServerDateCycle(dateCycle)
                     .then(() => {
                         console.log(`Server successfully updated for ${dateCycle.title}`);


### PR DESCRIPTION
## Summary
- Ensure push2today checks sessionStorage for `buwana_id`
- Treat logged-in users correctly and push date cycle updates when online

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aed1fc6620832ba6eaa5ff7840affe