### PR TITLE
Normalize callback query params

### DIFF
--- a/auth/callback/index.html
+++ b/auth/callback/index.html
@@ -42,7 +42,17 @@
     }, 400);
 
     (async function() {
-        const urlParams = new URLSearchParams(window.location.search);
+        // 🛠️ Some providers incorrectly append query parameters using '?' instead of '&'.
+        //    Normalize the query string so code and state can be parsed reliably.
+        let search = window.location.search;
+        if ((search.match(/\?/g) || []).length > 1) {
+            const parts = search.split('?');
+            search = '?' + parts.slice(1).join('&');
+            const newUrl = window.location.pathname + search + window.location.hash;
+            window.history.replaceState({}, '', newUrl);
+        }
+
+        const urlParams = new URLSearchParams(search);
         const code = urlParams.get("code");
         const state = urlParams.get("state");
         const status = urlParams.get("status");


### PR DESCRIPTION
## Summary
- Normalize OAuth callback query strings by replacing stray `?` with `&`
- Guard against malformed login URLs so `code` and `state` are always parsed

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af117e1ed8832ba5b2441310c74fb4