### PR TITLE
Clean up comment handling during dateCycle sync

### DIFF
--- a/js/1-event-management.js
+++ b/js/1-event-management.js
@@ -658,7 +658,7 @@ function writeMatchingDateCycles(divElement, dateCycle) {
                     </div>
                 </div>
                 <div class="current-date-notes" style="height: fit-content; max-width:300px;">
-                    ${dateCycle.comments}
+                    ${dateCycle.comments || ''}
                 </div>
             </div>
 
@@ -749,11 +749,26 @@ function initializeToggleListener() {
 
 
 async function updateServerDateCycle(dateCycle) {
+    // Ensure comment text field isn't populated with numeric zeroes
+    const commentsSanitized =
+        dateCycle.comment == 1 &&
+        dateCycle.comments &&
+        dateCycle.comments !== 0 &&
+        dateCycle.comments !== "0" &&
+        dateCycle.comments !== "null"
+            ? dateCycle.comments
+            : "";
+    const sanitized = {
+        ...dateCycle,
+        comment: commentsSanitized ? 1 : 0,
+        comments: commentsSanitized
+    };
+
     // Send the updated dateCycle object to the upsert endpoint
     const response = await fetch('https://buwana.ecobricks.org/earthcal/upsert_datecycle.php', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(dateCycle)
+        body: JSON.stringify(sanitized)
     });
 
     const data = await response.json();
@@ -762,12 +777,24 @@ async function updateServerDateCycle(dateCycle) {
         throw new Error(data.message || 'Failed to upsert dateCycle on server.');
     }
 
+    // Reflect sanitized field locally
+    dateCycle.comments = sanitized.comments;
+
     return data;
 }
 
 
 // Push a completion update via the unified upsert endpoint
 async function pushCompletionUpdate(dateCycle, buwanaId) {
+    const commentsSanitized =
+        dateCycle.comment == 1 &&
+        dateCycle.comments &&
+        dateCycle.comments !== 0 &&
+        dateCycle.comments !== "0" &&
+        dateCycle.comments !== "null"
+            ? dateCycle.comments
+            : "";
+
     const payload = {
         buwana_id: buwanaId,
         unique_key: String(dateCycle.unique_key),
@@ -788,8 +815,8 @@ async function pushCompletionUpdate(dateCycle, buwanaId) {
         datecycle_color: dateCycle.datecycle_color || "green",
         date_emoji: dateCycle.date_emoji || "📆",
         pinned: Number(dateCycle.pinned || 0),
-        comment: Number(dateCycle.comment || 0),
-        comments: dateCycle.comments || "",
+        comment: commentsSanitized ? 1 : 0,
+        comments: commentsSanitized,
         completed: Number(dateCycle.completed || 0),
         public: Number(dateCycle.public || 1),
         delete_it: Number(dateCycle.delete_it || 0),
@@ -1806,6 +1833,26 @@ async function syncDatecycles() {
 
         console.log(`🌿 Starting dateCycle sync for buwana_id ${buwanaId}...`);
 
+        // 🧹 Clean up any local dateCycles with numeric zero comments
+        Object.keys(localStorage)
+            .filter(k => k.startsWith('calendar_'))
+            .forEach(k => {
+                const arr = JSON.parse(localStorage.getItem(k) || '[]');
+                let dirty = false;
+                arr.forEach(dc => {
+                    if (
+                        dc.comments === 0 ||
+                        dc.comments === '0' ||
+                        dc.comments === null ||
+                        dc.comments === 'null'
+                    ) {
+                        dc.comments = '';
+                        dirty = true;
+                    }
+                });
+                if (dirty) localStorage.setItem(k, JSON.stringify(arr));
+            });
+
         let serverCalendars = [];
         let hasInternetConnection = 1;
         let totalDateCyclesUpdated = 0;
@@ -1983,10 +2030,21 @@ async function updateServerDatecycles(cal_id, dateCycles) {
         // Only push those not yet synced
         if (dc.synced === 1 || dc.synced === "1") continue;
 
+        const commentsSanitized =
+            dc.comment == 1 &&
+            dc.comments &&
+            dc.comments !== 0 &&
+            dc.comments !== "0" &&
+            dc.comments !== "null"
+                ? dc.comments
+                : "";
+
         const dateCycleToSend = {
             ...dc,
             buwana_id: buwanaId,
             cal_id: cal_id,
+            comment: commentsSanitized ? 1 : 0,
+            comments: commentsSanitized,
             last_edited: new Date().toISOString().slice(0, 19).replace('T', ' ')
         };
 
@@ -2004,6 +2062,7 @@ async function updateServerDatecycles(cal_id, dateCycles) {
             }
 
             dc.synced = 1; // Mark as synced
+            dc.comments = commentsSanitized; // keep local copy clean
             updated++;
         } catch (err) {
             console.error("⚠️ Failed to push dateCycle to server:", err);
@@ -2049,9 +2108,21 @@ async function updateLocalDatecycles(cal_id, serverDateCycles) {
         const key = serverDC.unique_key;
         const isNewer = !map[key] || new Date(serverDC.last_edited) > new Date(map[key].last_edited);
 
+        const commentsSanitized =
+            serverDC.comment == 1 &&
+            serverDC.comments &&
+            serverDC.comments !== 0 &&
+            serverDC.comments !== "0" &&
+            serverDC.comments !== "null"
+                ? serverDC.comments
+                : "";
+        const commentFlag = commentsSanitized ? 1 : 0;
+
         if (isNewer) {
             map[key] = {
                 ...serverDC,
+                comment: commentFlag,
+                comments: commentsSanitized,
                 synced: 1
             };
         }


### PR DESCRIPTION
## Summary
- Sanitize blank `comments` values to empty strings so UI never shows `null` or `0`
- Purge any stray `0`/`null` comment text from local dateCycles during sync
- Render `comments` with fallback to empty string when displaying events

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b00d3ee68c832b914fbca3f36aa617