### PR TITLE
Clear local calendars when user not logged in

### DIFF
--- a/js/login-scripts.js
+++ b/js/login-scripts.js
@@ -124,6 +124,12 @@ async function getUserData() {
 
     if (!ok || !payload?.buwana_id) {
         console.warn("⚪ Not logged in or token expired. Using default view.");
+        Object.keys(localStorage).forEach(key => {
+            if (key.startsWith("calendar_")) {
+                localStorage.removeItem(key);
+            }
+        });
+        sessionStorage.removeItem("user_calendars");
         useDefaultUser();
         return;
     }


### PR DESCRIPTION
## Summary
- Clear any locally cached calendars when the user is not authenticated

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b01c5abe54832b831b9a515aa9a84c