### PR TITLE
refactor: move head scripts to init file

### DIFF
--- a/dash.html
+++ b/dash.html
@@ -93,45 +93,7 @@
             content="width=device-width, initial-scale=1.0, target-density dpi=160, maximum-scale=5, user-scalable = yes"
     />
 
-    <script>
-        // Register the service worker
-        if ("serviceWorker" in navigator) {
-            window.addEventListener("load", function () {
-                navigator.serviceWorker
-                    .register("js/service-worker.js?v=3.0")
-                    .then(
-                        function (registration) {
-                            console.log(
-                                "ServiceWorker registration successful with scope:",
-                                registration.scope
-                            );
-                        },
-                        function (error) {
-                            console.log("ServiceWorker registration failed:", error);
-                        }
-                    );
-            });
-        }
-    </script>
-
-
-    <script src="js/gsap.min.js"></script>
-    <script src="js/MotionPathPlugin.min.js"></script>
-    <script src="js/suncalc.min.js"></script>
-    <script src="js/astronomy.browser.js"></script><!-- Functional orbital calculations-->
-
-    <!--<script src="https://cdn.jsdelivr.net/npm/hijri-js@1.0.25/dist/hijri-js.common.min.js"></script>-->
-
-    <script src="js/hijri-js.common.min.js"></script>
-    <!--This loads the main calendar javascript -->
-
-    <script src="js/core-javascripts.js?v=2"></script> <!--functional scripts-->
-    <script src="js/breakouts.js"></script> <!--breakout control scripts-->
-    <script src="js/set-targetdate.js"></script> <!--functional scripts-->
-    <script src="js/1-lunar-scripts.js"></script><!-- concerning the moon-->
-    <script src="js/planet-orbits.js"></script><!--planets-->
-    <script src="js/login-scripts.js"></script><!--planets-->
-    <script src="js/time-setting.js"></script><!--setting user time, timezone, clock-->
+    <script src="js/earthcal-init.js"></script>
 
     <!--Default Light Styles to load first-->
     <link rel="preload" href="css/light.css?v5.2" as="style" onload="this.rel='stylesheet'">
@@ -142,8 +104,6 @@
     <link rel="stylesheet" href="css/slider.css?v=1.2">
 
 
-    <!--This enables the Light and Dark mode switching-->
-    <script type="module" src="js/dark-mode-toggle.mjs.js" async></script>
 
 
     <!-- Main Calendar Stylesheet-->

--- a/js/earthcal-init.js
+++ b/js/earthcal-init.js
@@ -1,0 +1,51 @@
+// Register the service worker
+if ("serviceWorker" in navigator) {
+    window.addEventListener("load", function () {
+        navigator.serviceWorker
+            .register("js/service-worker.js?v=3.0")
+            .then(
+                function (registration) {
+                    console.log(
+                        "ServiceWorker registration successful with scope:",
+                        registration.scope
+                    );
+                },
+                function (error) {
+                    console.log("ServiceWorker registration failed:", error);
+                }
+            );
+    });
+}
+
+// Load required scripts sequentially
+const scripts = [
+    "js/gsap.min.js",
+    "js/MotionPathPlugin.min.js",
+    "js/suncalc.min.js",
+    "js/astronomy.browser.js",
+    "js/hijri-js.common.min.js",
+    "js/core-javascripts.js?v=2",
+    "js/breakouts.js",
+    "js/set-targetdate.js",
+    "js/1-lunar-scripts.js",
+    "js/planet-orbits.js",
+    "js/login-scripts.js",
+    "js/time-setting.js",
+];
+
+function loadScriptsSequentially(index) {
+    if (index >= scripts.length) {
+        const moduleScript = document.createElement("script");
+        moduleScript.type = "module";
+        moduleScript.src = "js/dark-mode-toggle.mjs.js";
+        moduleScript.async = true;
+        document.head.appendChild(moduleScript);
+        return;
+    }
+    const s = document.createElement("script");
+    s.src = scripts[index];
+    s.onload = () => loadScriptsSequentially(index + 1);
+    document.head.appendChild(s);
+}
+
+loadScriptsSequentially(0);


### PR DESCRIPTION
## Summary
- extract service worker registration and script loading from dash.html into `js/earthcal-init.js`
- load dependencies sequentially via new init file and replace head scripts with single tag

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3c60e4964832b817131f61b49bc60