### PR TITLE
fix script loading order

### DIFF
--- a/dash.html
+++ b/dash.html
@@ -276,8 +276,24 @@
             text-decoration: underline;
         }
     </style>
-
+    <script src="js/gsap.min.js"></script>
+    <script src="js/MotionPathPlugin.min.js"></script>
     <script>
+        function displayMoonPhaseOnHover(event) {
+            const pathId = event.target.id;
+            const [dayOfYear, day, month, year] = pathId.split('-').slice(0, 4);
+            const date = new Date(year, month - 1, day);
+            displayMoonPhaseInDiv(date);
+            updateMoonPhase(date);
+        }
+    </script>
+    <script src="js/1-lunar-scripts.js"></script>
+    <script>
+        function displayCurrentMoonPhase() {
+            displayMoonPhaseInDiv(targetDate);
+            updateMoonPhase(targetDate);
+        }
+
         //Initiate
         gsap.registerPlugin(MotionPathPlugin);
 

--- a/js/earthcal-init.js
+++ b/js/earthcal-init.js
@@ -19,15 +19,11 @@ if ("serviceWorker" in navigator) {
 
 // Load required scripts sequentially
 const scripts = [
-    "js/gsap.min.js",
-    "js/MotionPathPlugin.min.js",
     "js/suncalc.min.js",
     "js/astronomy.browser.js",
-    "js/hijri-js.common.min.js",
     "js/core-javascripts.js?v=2",
     "js/breakouts.js",
     "js/set-targetdate.js",
-    "js/1-lunar-scripts.js",
     "js/planet-orbits.js",
     "js/login-scripts.js",
     "js/time-setting.js",


### PR DESCRIPTION
## Summary
- load GSAP and lunar scripts directly in dash.html and add missing moon phase helpers
- streamline earthcal-init.js to sequentially load only essential modules

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b3d28d27b4832b815b75e14d4036be