### PR TITLE
Load calendar scripts via init sequence

### DIFF
--- a/dash.html
+++ b/dash.html
@@ -133,7 +133,7 @@
         gsap.registerPlugin(MotionPathPlugin);
 
         /*ROLL CALL*/
-        window.onload = async function () {
+        async function initializePage() {
             const solarCenterDiv = document.getElementById('solar-system-center');
             const dayLinesDiv = document.getElementById('days-of-year-lines');
             const allDaymarkers = document.getElementById('all-daymarkers');
@@ -242,7 +242,7 @@
             // setTimeout(triggerBreakoutDay,4000);  //allows the selected breakout to be highlighted
             await getUserData(); // This sets time_zone, targetDate, etc.
             displayDayInfo(targetDate, userLanguage, userTimeZone);
-        };
+        }
 
     </script>
 </HEAD>
@@ -973,7 +973,6 @@
 <!-- FINAL LOADED SCRIPTS -->
 
 <script src="js/1-event-management.js?v=2"></script>
-<script src="js/calendar-scripts.js"></script>
 <script src="js/kin-cycles.js"></script>
 
 

--- a/js/earthcal-init.js
+++ b/js/earthcal-init.js
@@ -34,6 +34,7 @@ async function initCalendar() {
         "js/planet-orbits.js",
         "js/login-scripts.js",
         "js/time-setting.js",
+        "js/calendar-scripts.js",
     ];
 
     try {
@@ -73,6 +74,10 @@ async function initCalendar() {
         moduleScript.type = "module";
         moduleScript.src = "js/dark-mode-toggle.mjs.js";
         document.head.appendChild(moduleScript);
+
+        if (typeof initializePage === "function") {
+            initializePage();
+        }
     } catch (err) {
         console.error("Initialization error:", err);
     } finally {


### PR DESCRIPTION
## Summary
- Load `calendar-scripts.js` through `earthcal-init.js` after the SVG and core scripts
- Trigger page setup via `initializePage()` once all scripts are ready and remove direct script tag

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b57e26a4d8832b95cb3e2389ba69b0