### PR TITLE
Center calendar spinner with moon phase animation

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -1791,45 +1791,31 @@ TOOLTIPS AND MODALS
   width: 50%;
 }
 
-/* Loading spinner overlay */
-#loading-spinner {
-    position: fixed;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 1000;
-}
-
-#loading-spinner::after {
-    content: "";
-    position: fixed;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 48px;
-    height: 48px;
-    border: 6px solid var(--button-2-1);
-    border-top-color: var(--h1);
-    border-radius: 50%;
-    animation: spin 1s linear infinite;
-}
-
-#loading-spinner.hidden {
-    display: none;
-}
-
-@keyframes spin {
-    to {
-        transform: translate(-50%, -50%) rotate(360deg);
-    }
-}
     #current-date-info {
     max-width: 500px;
     font-size: 1.45em;
 }
 
 }
+
+/* Calendar container and loading spinner */
+#calendar-container {
+    position: relative;
+}
+
+#loading-spinner {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 48px;
+    z-index: 1000;
+}
+
+#loading-spinner.hidden {
+    display: none;
+}
+
 /*
 .search-button {
   z-index: 20;

--- a/dash.html
+++ b/dash.html
@@ -731,10 +731,11 @@
         </div>
     </div>
 
-    <div id="loading-spinner"></div>
-
-    <div id="the-cal">
-        <!--Init will Insert the The raw file here-->
+    <div id="calendar-container">
+        <div id="the-cal">
+            <!--Init will Insert the The raw file here-->
+        </div>
+        <div id="loading-spinner">🌑</div>
     </div>
 
     <!-- MAIN PAGE MENU -->

--- a/js/earthcal-init.js
+++ b/js/earthcal-init.js
@@ -21,7 +21,15 @@ document.addEventListener("DOMContentLoaded", initCalendar);
 
 async function initCalendar() {
     const spinner = document.getElementById("loading-spinner");
+    let phaseInterval;
     if (spinner) {
+        const phases = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"];
+        let index = 0;
+        spinner.textContent = phases[index];
+        phaseInterval = setInterval(() => {
+            index = (index + 1) % phases.length;
+            spinner.textContent = phases[index];
+        }, 400);
         spinner.classList.remove("hidden");
     }
 
@@ -83,6 +91,9 @@ async function initCalendar() {
     } finally {
         if (spinner) {
             spinner.classList.add("hidden");
+            if (phaseInterval) {
+                clearInterval(phaseInterval);
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Position loading spinner over the calendar container instead of the full page
- Replace spinner graphic with cycling moon phase emojis
- Animate moon phases every 0.4s and clear interval after load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b5c6570c64832bb7d96cb7a8eff1e8