### PR TITLE
Center loading spinner in calendar

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -1798,8 +1798,8 @@ TOOLTIPS AND MODALS
 
 }
 
-/* Calendar container and loading spinner */
-#calendar-container {
+/* Calendar and loading spinner */
+#the-cal {
     position: relative;
 }
 

--- a/dash.html
+++ b/dash.html
@@ -731,10 +731,8 @@
         </div>
     </div>
 
-    <div id="calendar-container">
-        <div id="the-cal">
-            <!--Init will Insert the The raw file here-->
-        </div>
+    <div id="the-cal">
+        <!--Init will Insert the The raw file here-->
         <div id="loading-spinner">🌑</div>
     </div>
 

--- a/js/earthcal-init.js
+++ b/js/earthcal-init.js
@@ -51,7 +51,7 @@ async function initCalendar() {
             const svg = await response.text();
             const calContainer = document.getElementById("the-cal");
             if (calContainer) {
-                calContainer.innerHTML = svg;
+                calContainer.insertAdjacentHTML('afterbegin', svg);
             }
         } catch (err) {
             console.error("Failed to load SVG", err);


### PR DESCRIPTION
## Summary
- Restore simpler calendar container markup
- Center moon-phase loading spinner within calendar using absolute positioning
- Load SVG without overwriting spinner element

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b66983ed34832b9c2cad9e93a3d288