### PR TITLE
Fix calendar container sizing to display SVG

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -1801,6 +1801,8 @@ TOOLTIPS AND MODALS
 /* Calendar and loading spinner */
 #the-cal {
     position: relative;
+    min-height: 100vh;
+    width: 100%;
 }
 
 #loading-spinner {
@@ -1814,6 +1816,11 @@ TOOLTIPS AND MODALS
 
 #loading-spinner.hidden {
     display: none;
+}
+
+#the-cal svg {
+    width: 100%;
+    height: auto;
 }
 
 /*


### PR DESCRIPTION
## Summary
- Ensure the calendar container has explicit dimensions so the SVG renders
- Force the calendar SVG to scale responsively

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b67524c57c832b84df23b4f409b089