### PR TITLE
Revert dashboard files to post-PR45 state

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -1791,38 +1791,45 @@ TOOLTIPS AND MODALS
   width: 50%;
 }
 
-    #current-date-info {
-    max-width: 500px;
-    font-size: 1.45em;
-}
-
-}
-
-/* Calendar and loading spinner */
-#the-cal {
-    position: relative;
-    min-height: 100vh;
-    width: 100%;
-}
-
+/* Loading spinner overlay */
 #loading-spinner {
-    position: absolute;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1000;
+}
+
+#loading-spinner::after {
+    content: "";
+    position: fixed;
     top: 50%;
     left: 50%;
     transform: translate(-50%, -50%);
-    font-size: 48px;
-    z-index: 1000;
+    width: 48px;
+    height: 48px;
+    border: 6px solid var(--button-2-1);
+    border-top-color: var(--h1);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
 }
 
 #loading-spinner.hidden {
     display: none;
 }
 
-#the-cal svg {
-    width: 100%;
-    height: auto;
+@keyframes spin {
+    to {
+        transform: translate(-50%, -50%) rotate(360deg);
+    }
+}
+    #current-date-info {
+    max-width: 500px;
+    font-size: 1.45em;
 }
 
+}
 /*
 .search-button {
   z-index: 20;

--- a/dash.html
+++ b/dash.html
@@ -731,9 +731,10 @@
         </div>
     </div>
 
+    <div id="loading-spinner"></div>
+
     <div id="the-cal">
         <!--Init will Insert the The raw file here-->
-        <div id="loading-spinner">🌑</div>
     </div>
 
     <!-- MAIN PAGE MENU -->

--- a/js/earthcal-init.js
+++ b/js/earthcal-init.js
@@ -21,15 +21,7 @@ document.addEventListener("DOMContentLoaded", initCalendar);
 
 async function initCalendar() {
     const spinner = document.getElementById("loading-spinner");
-    let phaseInterval;
     if (spinner) {
-        const phases = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"];
-        let index = 0;
-        spinner.textContent = phases[index];
-        phaseInterval = setInterval(() => {
-            index = (index + 1) % phases.length;
-            spinner.textContent = phases[index];
-        }, 400);
         spinner.classList.remove("hidden");
     }
 
@@ -51,7 +43,7 @@ async function initCalendar() {
             const svg = await response.text();
             const calContainer = document.getElementById("the-cal");
             if (calContainer) {
-                calContainer.insertAdjacentHTML('afterbegin', svg);
+                calContainer.innerHTML = svg;
             }
         } catch (err) {
             console.error("Failed to load SVG", err);
@@ -91,9 +83,6 @@ async function initCalendar() {
     } finally {
         if (spinner) {
             spinner.classList.add("hidden");
-            if (phaseInterval) {
-                clearInterval(phaseInterval);
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Restore dash.html to include init script before style loading
- Revert css/1-stylesheet.css to earlier baseline styles
- Reinstate earthcal-init.js for sequential calendar initialization

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b7189d78d0832b9ad22462c10ca026