### PR TITLE
Hide spinner and restore login status indicator

### DIFF
--- a/dash.html
+++ b/dash.html
@@ -731,7 +731,7 @@
         </div>
     </div>
 
-    <div id="loading-spinner"></div>
+    <div id="loading-spinner" style="display:none !important;"></div>
 
     <div id="the-cal">
         <!--Init will Insert the The raw file here-->

--- a/js/login-scripts.js
+++ b/js/login-scripts.js
@@ -131,6 +131,7 @@ async function getUserData() {
         });
         sessionStorage.removeItem("user_calendars");
         useDefaultUser();
+        updateSessionStatus("⚪ Not logged in", false);
         return;
     }
 
@@ -154,6 +155,11 @@ async function getUserData() {
     };
 
     console.log("✅ Loaded userProfile:", userProfile);
+
+    updateSessionStatus(
+        `🟢 Logged in as ${userProfile.first_name} ${userProfile.earthling_emoji}`,
+        true
+    );
 
     displayUserData(userTimeZone, userLanguage);
     setCurrentDate(userTimeZone, userLanguage);


### PR DESCRIPTION
## Summary
- Force the dashboard's loading spinner to stay hidden
- Update getUserData to toggle login status indicator when user info is loaded or missing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9122de9c8832b85c62b25a76d472a