### PR TITLE
refactor: remove page blur for modals

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -1965,6 +1965,10 @@ GUIDED TOUR---*
   pointer-events: none;
 }
 
+.dim-blur {
+  background: rgba(255, 255, 255, 0.25);
+}
+
 .next {
   background-color: green;
   border: none;

--- a/css/light.css
+++ b/css/light.css
@@ -370,7 +370,12 @@
 
 /*
 .blur {
-  background: #ededed;}*/
+  background: #ededed;}
+*/
+
+.dim-blur {
+  background: rgba(255, 255, 255, 0.25);
+}
 .x-button {
   background: url(../svgs/x-day.svg) center no-repeat;
   background-size: contain;

--- a/js/1-event-management.js
+++ b/js/1-event-management.js
@@ -4,7 +4,8 @@ async function openAddCycle() {
     console.log('openAddCycle called');
     document.body.style.overflowY = 'hidden';
     document.getElementById('add-datecycle').classList.replace('modal-hidden','modal-shown');
-    document.getElementById('page-content').classList.add('blur');
+    const header = document.getElementById('add-datecycle-info');
+    if (header) header.classList.add('dim-blur');
     populateDateFields(targetDate);
 
     const confirmBtn = document.getElementById('confirm-dateCycle-button');
@@ -371,7 +372,6 @@ function closeAddCycle() {
 
     document.getElementById("add-datecycle").classList.add('modal-hidden');
     document.getElementById("add-datecycle").classList.remove('modal-shown');
-    document.getElementById("page-content").classList.remove("blur");
 
     // Reset select-cal to default value
     let selectCal = document.getElementById("select-cal");

--- a/js/calendar-scripts.js
+++ b/js/calendar-scripts.js
@@ -298,7 +298,8 @@ function closeTheModal() {
     // Hide the modal
     modal.classList.remove('modal-visible');
     modal.classList.add('modal-hidden');
-    document.getElementById("page-content").classList.remove("blur");
+
+    document.body.style.overflowY = 'unset';
 
     modalOpen = false;
 

--- a/js/core-javascripts.js
+++ b/js/core-javascripts.js
@@ -47,11 +47,9 @@ function ensurePlanetData(date) {
 // Close the day search modal
 function closeSearchModal() {
   const modal = document.getElementById("day-search");
-  const underContent = document.getElementById("page-content");
-
-  underContent.classList.remove("blur");
   modal.classList.remove("modal-shown");
   modal.classList.add("modal-hidden");
+  document.body.style.overflowY = "unset";
 }
 
 // Open the day search modal
@@ -96,7 +94,11 @@ async function openDateSearch() {
 
     modal.classList.remove("modal-hidden");
     modal.classList.add("modal-shown");
-    document.getElementById("page-content").classList.add("blur");
+    document.body.style.overflowY = "hidden";
+    const header = document.getElementById("date-search-title");
+    if (header) header.classList.add("dim-blur");
+    const icon = modal.querySelector(".top-search-icon");
+    if (icon) icon.classList.add("dim-blur");
 
     const searchedYear = document.querySelector(".searched-year");
     let year = targetDate.getFullYear();

--- a/js/time-setting.js
+++ b/js/time-setting.js
@@ -258,9 +258,12 @@ async function showUserCalSettings() {
         </form>
     `;
 
+    const header = modalContent.querySelector('.top-settings-icon');
+    if (header) header.classList.add('dim-blur');
+
     modal.classList.remove('modal-hidden');
     modal.classList.add('modal-visible');
-    document.getElementById("page-content").classList.add("blur");
+    document.body.style.overflowY = 'hidden';
 
     modal.setAttribute('tabindex', '0');
     modal.focus();


### PR DESCRIPTION
## Summary
- stop blurring page content when opening Add Cycle, Date Search, and User Settings modals
- add `dim-blur` header overlay for full-screen modals
- standardize modal open/close behavior by managing page scroll

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b96a7b1888832b869b3811f791d684