### PR TITLE
Apply dim-blur effect directly to modals

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -1966,7 +1966,8 @@ GUIDED TOUR---*
 }
 
 .dim-blur {
-  background: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.7);
+  border: 2px solid red;
 }
 
 .next {
@@ -2696,7 +2697,6 @@ INFO MODAL
 .modal-content-box {
     position: relative;
     padding: 20px;
-    background-color: var(--general-background);/*Problem?!*/
     border-radius: 10px;
     max-width: 90%;
     max-height: 90vh; /* Restrict the modal height to 90% of the viewport */

--- a/css/light.css
+++ b/css/light.css
@@ -374,7 +374,8 @@
 */
 
 .dim-blur {
-  background: rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.7);
+  border: 2px solid red;
 }
 .x-button {
   background: url(../svgs/x-day.svg) center no-repeat;

--- a/js/1-event-management.js
+++ b/js/1-event-management.js
@@ -3,9 +3,9 @@
 async function openAddCycle() {
     console.log('openAddCycle called');
     document.body.style.overflowY = 'hidden';
-    document.getElementById('add-datecycle').classList.replace('modal-hidden','modal-shown');
-    const header = document.getElementById('add-datecycle-info');
-    if (header) header.classList.add('dim-blur');
+    const modal = document.getElementById('add-datecycle');
+    modal.classList.replace('modal-hidden','modal-shown');
+    modal.classList.add('dim-blur');
     populateDateFields(targetDate);
 
     const confirmBtn = document.getElementById('confirm-dateCycle-button');
@@ -370,8 +370,10 @@ function closeAddCycle() {
     document.body.style.overflowY = "unset";
     document.body.style.maxHeight = "unset";
 
-    document.getElementById("add-datecycle").classList.add('modal-hidden');
-    document.getElementById("add-datecycle").classList.remove('modal-shown');
+    const modal = document.getElementById("add-datecycle");
+    modal.classList.add('modal-hidden');
+    modal.classList.remove('modal-shown');
+    modal.classList.remove('dim-blur');
 
     // Reset select-cal to default value
     let selectCal = document.getElementById("select-cal");

--- a/js/calendar-scripts.js
+++ b/js/calendar-scripts.js
@@ -294,6 +294,11 @@ function handleTouchEnd() {
 
 function closeTheModal() {
     const modal = document.getElementById('form-modal-message');
+    const box = document.getElementById('modal-content-box');
+    if (box) {
+        box.classList.remove('dim-blur');
+        box.style.backgroundColor = '';
+    }
 
     // Hide the modal
     modal.classList.remove('modal-visible');

--- a/js/core-javascripts.js
+++ b/js/core-javascripts.js
@@ -49,6 +49,7 @@ function closeSearchModal() {
   const modal = document.getElementById("day-search");
   modal.classList.remove("modal-shown");
   modal.classList.add("modal-hidden");
+  modal.classList.remove("dim-blur");
   document.body.style.overflowY = "unset";
 }
 
@@ -94,11 +95,8 @@ async function openDateSearch() {
 
     modal.classList.remove("modal-hidden");
     modal.classList.add("modal-shown");
+    modal.classList.add("dim-blur");
     document.body.style.overflowY = "hidden";
-    const header = document.getElementById("date-search-title");
-    if (header) header.classList.add("dim-blur");
-    const icon = modal.querySelector(".top-search-icon");
-    if (icon) icon.classList.add("dim-blur");
 
     const searchedYear = document.querySelector(".searched-year");
     let year = targetDate.getFullYear();

--- a/js/time-setting.js
+++ b/js/time-setting.js
@@ -258,8 +258,12 @@ async function showUserCalSettings() {
         </form>
     `;
 
-    const header = modalContent.querySelector('.top-settings-icon');
-    if (header) header.classList.add('dim-blur');
+    const contentBox = modal.querySelector('.modal-content-box');
+    if (contentBox) {
+        contentBox.id = 'modal-content-box';
+        contentBox.classList.add('dim-blur');
+        contentBox.style.backgroundColor = 'transparent';
+    }
 
     modal.classList.remove('modal-hidden');
     modal.classList.add('modal-visible');


### PR DESCRIPTION
## Summary
- Strengthen `dim-blur` styling with higher opacity and red border for visibility
- Apply `dim-blur` to Add Cycle, Date Search, and Settings modals while removing background color from settings box
- Clean up modal close routines to remove `dim-blur` class

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b97da3975c832ba1fe4ff836bd1f4f