### PR TITLE
Prevent showing Add DateCycle form when user not logged in

### DIFF
--- a/js/1-event-management.js
+++ b/js/1-event-management.js
@@ -2,14 +2,6 @@
 
 async function openAddCycle() {
     console.log('openAddCycle called');
-    document.body.style.overflowY = 'hidden';
-    const modal = document.getElementById('add-datecycle');
-    modal.classList.replace('modal-hidden','modal-shown');
-    modal.classList.add('dim-blur');
-    populateDateFields(targetDate);
-
-    const confirmBtn = document.getElementById('confirm-dateCycle-button');
-    if (confirmBtn) confirmBtn.innerText = '+ Add DateCycle';
 
     const craftBuwana =
         JSON.parse(sessionStorage.getItem('buwana_user') || '{}').buwana_id ||
@@ -18,8 +10,18 @@ async function openAddCycle() {
 
     if (!craftBuwana) {
         alert('Please log in to add events.');
+        sendUpRegistration();
         return;
     }
+
+    document.body.style.overflowY = 'hidden';
+    const modal = document.getElementById('add-datecycle');
+    modal.classList.replace('modal-hidden','modal-shown');
+    modal.classList.add('dim-blur');
+    populateDateFields(targetDate);
+
+    const confirmBtn = document.getElementById('confirm-dateCycle-button');
+    if (confirmBtn) confirmBtn.innerText = '+ Add DateCycle';
 
     await populateCalendarDropdown(craftBuwana);
 }


### PR DESCRIPTION
## Summary
- Avoid opening the Add DateCycle modal if no user is logged in
- Instead of showing the form, alert the user and launch registration/login via `sendUpRegistration()`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b9829f9678832b827f31d18a059458