### PR TITLE
Add stellar-submit class and spinner actions

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -2957,7 +2957,7 @@ svg path #june:hover {
 /* SYNCING  */
 
 /* General Sync Button Styling */
-.sync-style {
+.sync-style, .stellar-submit {
     position: relative;
     padding: 10px 20px;
     border-radius: 10px;
@@ -2970,12 +2970,12 @@ svg path #june:hover {
 }
 
 /* Loading State for Sync Buttons */
-.sync-style.loading {
+.sync-style.loading, .stellar-submit.loading {
     pointer-events: none; /* Disable button clicks during sync */
     background-color: grey;
 }
 
-.sync-style.loading::before {
+.sync-style.loading::before, .stellar-submit.loading::before {
     content: "";
     position: absolute;
     left: 10px;
@@ -2995,7 +2995,7 @@ svg path #june:hover {
 }
 
 /* Hover Effect */
-.sync-style:hover {
+.sync-style:hover, .stellar-submit:hover {
     background-color: var(--button-2-1-over);
 
 }

--- a/dash.html
+++ b/dash.html
@@ -305,8 +305,7 @@
 
         <button
                 id="search-button"
-                class="confirmation-blur-button"
-                onclick="closeSearchModal()">
+                class="stellar-submit">
         </button>
     </div>
 </div>
@@ -542,7 +541,7 @@
                     <textarea id="add-date-note" placeholder="Add a note to this event..." class="blur-form-field"></textarea>
                 </div>
 
-                <button type="button" id="confirm-dateCycle-button" class="sync-style" onclick="animateConfirmDateCycleButton();" style="width:70%;height:45px;margin-top: 18px;">
+                <button type="button" id="confirm-dateCycle-button" class="stellar-submit" onclick="animateConfirmDateCycleButton();" style="width:70%;height:45px;margin-top: 18px;">
                     + Add Event Please
                 </button>
 

--- a/js/core-javascripts.js
+++ b/js/core-javascripts.js
@@ -112,10 +112,14 @@ const t = translations.openDateSearch || {};
 
         if (!validateDate(day, month, yeard, t)) return;
 
-
-        targetDate = new Date(yeard, month - 1, day);
-        searchGoDate(targetDate);
-        closeSearchModal();
+        searchButton.classList.add('loading');
+        setTimeout(() => {
+            searchButton.classList.remove('loading');
+            searchButton.innerText = 'Searching…';
+            targetDate = new Date(yeard, month - 1, day);
+            searchGoDate(targetDate);
+            closeSearchModal();
+        }, 500);
     };
 
     prevYearButton.onclick = () => {

--- a/js/time-setting.js
+++ b/js/time-setting.js
@@ -252,7 +252,7 @@ async function showUserCalSettings() {
                     </dark-mode-toggle>
                 </div>
             </div>
-            <button type="button" name="apply" onclick="applySettings()" class="confirmation-blur-button">
+            <button type="button" name="apply" onclick="animateApplySettingsButton()" class="stellar-submit">
                 ${settingsContent.applySettings}
             </button>
         </form>
@@ -288,6 +288,17 @@ function getUtcOffset(tz) {
 }
 
 
+
+function animateApplySettingsButton() {
+    const applyButton = document.querySelector('#user-settings-form button[name="apply"]');
+    if (!applyButton) return;
+    applyButton.classList.add('loading');
+    setTimeout(() => {
+        applyButton.classList.remove('loading');
+        applyButton.innerText = 'Settings Updated!';
+        applySettings();
+    }, 500);
+}
 
 async function applySettings() {
     const timezoneSelect = document.getElementById('timezone');


### PR DESCRIPTION
## Summary
- Add `stellar-submit` button style with loading spinner
- Replace search and settings form buttons to use new style and show brief spinner feedback
- Wire up search and settings buttons to display messages after 0.5s

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbacfa4c98832b8d570366108b0e5d