### PR TITLE
Improve modal submission UX

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -2969,6 +2969,10 @@ svg path #june:hover {
     cursor: pointer;
 }
 
+.stellar-submit {
+    width: 100%;
+}
+
 /* Loading State for Sync Buttons */
 .sync-style.loading, .stellar-submit.loading {
     pointer-events: none; /* Disable button clicks during sync */

--- a/css/light.css
+++ b/css/light.css
@@ -375,7 +375,6 @@
 
 .dim-blur {
   background: rgba(255, 255, 255, 0.7);
-  border: 2px solid red;
 }
 .x-button {
   background: url(../svgs/x-day.svg) center no-repeat;

--- a/js/core-javascripts.js
+++ b/js/core-javascripts.js
@@ -105,6 +105,7 @@ async function openDateSearch() {
     dayField.value = targetDate.getDate();
     monthField.value = targetDate.getMonth() + 1;
 const t = translations.openDateSearch || {};
+const searchingText = t.searching || 'Searching...';
     searchButton.onclick = () => {
         const day = parseInt(dayField.value, 10);
         const month = parseInt(monthField.value, 10);
@@ -113,13 +114,10 @@ const t = translations.openDateSearch || {};
         if (!validateDate(day, month, yeard, t)) return;
 
         searchButton.classList.add('loading');
-        setTimeout(() => {
-            searchButton.classList.remove('loading');
-            searchButton.innerText = 'Searching…';
-            targetDate = new Date(yeard, month - 1, day);
-            searchGoDate(targetDate);
-            closeSearchModal();
-        }, 500);
+        searchButton.innerText = searchingText;
+        targetDate = new Date(yeard, month - 1, day);
+        searchGoDate(targetDate);
+        closeSearchModal();
     };
 
     prevYearButton.onclick = () => {

--- a/js/time-setting.js
+++ b/js/time-setting.js
@@ -289,15 +289,16 @@ function getUtcOffset(tz) {
 
 
 
-function animateApplySettingsButton() {
+async function animateApplySettingsButton() {
     const applyButton = document.querySelector('#user-settings-form button[name="apply"]');
     if (!applyButton) return;
+    const lang = (userLanguage || 'en').toLowerCase();
+    const translations = await loadTranslations(lang);
+    const savingText = translations.settings?.saving || 'Saving...';
     applyButton.classList.add('loading');
-    setTimeout(() => {
-        applyButton.classList.remove('loading');
-        applyButton.innerText = 'Settings Updated!';
-        applySettings();
-    }, 500);
+    applyButton.innerText = savingText;
+    await applySettings();
+    applyButton.classList.remove('loading');
 }
 
 async function applySettings() {

--- a/translations/ar.js
+++ b/translations/ar.js
@@ -89,6 +89,7 @@ export const translations = {
       AR: "AR - العربية"
     },
     applySettings: "تطبيق الإعدادات",
+    saving: "جارٍ الحفظ...",
     darkMode: {
       legend: "تبديل بين الوضع الداكن والفاتح:",
       remember: "تذكر لجميع الصفحات"
@@ -108,7 +109,8 @@ openDateSearch: {
   goToDate: "الانتقال إلى التاريخ",
   invalidDay: "يرجى التأكد من اختيار يوم مناسب أقل من 31!",
   invalidFebruary: "يرجى التأكد من اختيار تاريخ مناسب لشهر فبراير!",
-  invalidLeapYear: "يرجى اختيار يوم أقل من 29 لشهر فبراير في سنة غير كبيسة!"
+  invalidLeapYear: "يرجى اختيار يوم أقل من 29 لشهر فبراير في سنة غير كبيسة!",
+  searching: "جارٍ البحث..."
 },
 
 // LOG IN SCREEN

--- a/translations/de.js
+++ b/translations/de.js
@@ -89,6 +89,7 @@ export const translations = {
       AR: "AR - Arabisch"
     },
     applySettings: "Einstellungen anwenden",
+    saving: "Speichern...",
     darkMode: {
       legend: "Dunkel- und Hellmodus umschalten:",
       remember: "Für alle Seiten merken"
@@ -108,7 +109,8 @@ openDateSearch: {
   goToDate: "Zum Datum",
   invalidDay: "Bitte wähle ein gültiges Datum unter 31!",
   invalidFebruary: "Bitte wähle ein gültiges Datum für den Februar!",
-  invalidLeapYear: "Bitte wähle einen Tag unter 29 für Februar in einem Nicht-Schaltjahr!"
+  invalidLeapYear: "Bitte wähle einen Tag unter 29 für Februar in einem Nicht-Schaltjahr!",
+  searching: "Suchen..."
 },
 
 // LOG IN SCREEN

--- a/translations/en.js
+++ b/translations/en.js
@@ -92,6 +92,7 @@ settings: {
         ZH: "ZH - 中文" // ✅ Chinese added
     },
     applySettings: "Apply Settings",
+    saving: "Saving...",
     darkMode: {
         legend: "Toggle dark and light mode:",
         remember: "Remember for all pages"
@@ -112,7 +113,8 @@ settings: {
         goToDate: "Go to Date",
         invalidDay: "Please make sure you're choosing a reasonable date under 31!",
         invalidFebruary: "Please make sure you're choosing a reasonable date for February!",
-        invalidLeapYear: "Please choose a day under 29 for February in a non-leap year!"
+        invalidLeapYear: "Please choose a day under 29 for February in a non-leap year!",
+        searching: "Searching..."
     },
 
 

--- a/translations/es.js
+++ b/translations/es.js
@@ -89,9 +89,10 @@ export const translations = {
       ES: "ES - Español",
       DE: "DE - Alemán",
       AR: "AR - Árabe"
-    },
-    applySettings: "Aplicar Configuración",
-    darkMode: {
+  },
+  applySettings: "Aplicar Configuración",
+  saving: "Guardando...",
+  darkMode: {
       legend: "Cambiar entre modo claro y oscuro:",
       remember: "Recordar en todas las páginas"
     }
@@ -110,7 +111,8 @@ openDateSearch: {
   goToDate: "Ir a la Fecha",
   invalidDay: "¡Asegúrate de elegir una fecha válida menor de 31!",
   invalidFebruary: "¡Asegúrate de elegir una fecha válida para febrero!",
-  invalidLeapYear: "¡Elige un día menor de 29 para febrero en un año no bisiesto!"
+  invalidLeapYear: "¡Elige un día menor de 29 para febrero en un año no bisiesto!",
+  searching: "Buscando..."
 },
 
 // LOG IN SCREEN

--- a/translations/fr.js
+++ b/translations/fr.js
@@ -90,6 +90,7 @@ export const translations = {
       AR: "AR - Arabe"
     },
     applySettings: "Appliquer les Paramètres",
+    saving: "Enregistrement...",
     darkMode: {
       legend: "Basculer entre mode clair et sombre :",
       remember: "Se souvenir pour toutes les pages"
@@ -109,7 +110,8 @@ openDateSearch: {
   goToDate: "Aller à la date",
   invalidDay: "Veuillez choisir un jour raisonnable inférieur à 31 !",
   invalidFebruary: "Veuillez choisir une date raisonnable pour le mois de février !",
-  invalidLeapYear: "Veuillez choisir un jour inférieur à 29 pour février lors d’une année non bissextile !"
+  invalidLeapYear: "Veuillez choisir un jour inférieur à 29 pour février lors d’une année non bissextile !",
+  searching: "Recherche..."
 },
 
 // LOG IN SCREEN

--- a/translations/id.js
+++ b/translations/id.js
@@ -89,6 +89,7 @@ settings: {
     ZH: "ZH - 中文" // ✅ Added Chinese
   },
   applySettings: "Terapkan Pengaturan",
+  saving: "Menyimpan...",
   darkMode: {
     legend: "Ganti mode terang dan gelap:",
     remember: "Ingat untuk semua halaman"
@@ -109,7 +110,8 @@ openDateSearch: {
   goToDate: "Pergi ke Tanggal",
   invalidDay: "Pastikan Anda memilih tanggal yang wajar di bawah 31!",
   invalidFebruary: "Pastikan Anda memilih tanggal yang sesuai untuk bulan Februari!",
-  invalidLeapYear: "Silakan pilih hari di bawah 29 untuk Februari pada tahun bukan kabisat!"
+  invalidLeapYear: "Silakan pilih hari di bawah 29 untuk Februari pada tahun bukan kabisat!",
+  searching: "Mencari..."
 },
 
 // LOG IN SCREEN

--- a/translations/zh.js
+++ b/translations/zh.js
@@ -89,6 +89,7 @@ export const translations = {
       AR: "AR - 阿拉伯语"
     },
     applySettings: "应用设置",
+    saving: "保存中...",
     darkMode: {
       legend: "切换明暗模式：",
       remember: "记住所有页面的设置"
@@ -108,7 +109,8 @@ openDateSearch: {
   goToDate: "跳转到日期",
   invalidDay: "请选择一个不超过31的有效日期！",
   invalidFebruary: "请选择二月份的有效日期！",
-  invalidLeapYear: "平年中请选择二月份小于29号的日期！"
+  invalidLeapYear: "平年中请选择二月份小于29号的日期！",
+  searching: "搜索中..."
 },
 
 // LOG IN SCREEN


### PR DESCRIPTION
## Summary
- Show loading spinner and localized "Saving..." or "Searching..." text when submitting settings and date search modals
- Make modal submit buttons stretch full width and remove red border from dim-blur overlay
- Add translation strings for new loading messages across supported languages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbb48e3450832b802ad6b21bb99ace