### PR TITLE
Replace spinner with themed progress bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,15 +41,25 @@
                 color: white;
             }
         }
-        #spinner {
-            font-size: 3.5em;
+        #progress-container {
+            width: 250px;
+            height: 20px;
+            background-color: #333;
+            margin-top: 10px;
         }
         #load-progress {
             width: 0%;
-            height: 4px;
-            background-color: grey;
-            margin-top: 10px;
+            height: 100%;
+            background-color: #ccc;
             transition: width 0.3s ease;
+        }
+        @media (prefers-color-scheme: dark) {
+            #progress-container {
+                background-color: #ccc;
+            }
+            #load-progress {
+                background-color: #333;
+            }
         }
         h3 {
             font-size: 0.9em;
@@ -60,8 +70,7 @@
 </head>
 <body>
 <div class="earthcal-app-logo" style="margin-bottom: 20px;"><img src="svgs/earthcal-icon.svg" style="width:125px;height:125px;"></div>
-<div id="spinner" aria-hidden="true">🌑</div>
-<div id="load-progress"></div>
+<div id="progress-container"><div id="load-progress"></div></div>
 <h3>Loading Earthcal<span id="dots">...</span></h3>
 
 <script type="module">
@@ -87,14 +96,6 @@
         dotPhase = (dotPhase + 1) % 4;
         dotElem.textContent = ".".repeat(dotPhase);
     }, 400);
-
-    const spinner = document.getElementById("spinner");
-    const phases = ["🌑", "🌒", "🌓", "🌔", "🌕", "🌖", "🌗", "🌘"];
-    let phaseIndex = 0;
-    setInterval(() => {
-        spinner.textContent = phases[phaseIndex];
-        phaseIndex = (phaseIndex + 1) % phases.length;
-    }, 200);
 
     const assets = [
         "js/earthcal-init.js",
@@ -134,6 +135,8 @@
 
     (async function initApp() {
         const redirectTarget = "dash.html";
+        const MIN_WAIT = 2000;
+        const startTime = Date.now();
 
         if (!isLoggedIn()) {
             const defaultProfile = {
@@ -156,6 +159,10 @@
         }
 
         await preloadAssets();
+        const elapsed = Date.now() - startTime;
+        if (elapsed < MIN_WAIT) {
+            await new Promise((resolve) => setTimeout(resolve, MIN_WAIT - elapsed));
+        }
         window.location.href = redirectTarget;
     })();
 </script>


### PR DESCRIPTION
## Summary
- Remove moon emoji spinner and introduce 250x20 progress bar below Earthcal logo
- Apply light/dark theme colors for progress bar
- Enforce 2s minimum load delay before redirecting to dashboard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbd4333b28832b845523c8f7926e1f