### PR TITLE
Refine splash screen styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,6 +22,9 @@
     <link rel="preload" href="svgs/up-reg-arrow-light-active.svg" as="image">
     <link rel="preload" href="svgs/up-reg-arrow-light-active-hover.svg" as="image">
     <style>
+        :root {
+            --general-background: rgb(245, 245, 245);
+        }
         body {
             margin: 0;
             padding: 0;
@@ -31,13 +34,16 @@
             justify-content: center;
             height: 100vh;
             font-family: 'Arial', sans-serif;
-            background-color: white;
+            background-color: var(--general-background);
             color: black;
             transition: all 0.3s ease;
+            position: relative;
         }
         @media (prefers-color-scheme: dark) {
+            :root {
+                --general-background: rgb(13, 15, 26);
+            }
             body {
-                background-color: #111;
                 color: white;
             }
         }
@@ -46,12 +52,15 @@
             height: 20px;
             background-color: #333;
             margin-top: 10px;
+            border-radius: 10px;
+            overflow: hidden;
         }
         #load-progress {
             width: 0%;
             height: 100%;
             background-color: #ccc;
             transition: width 0.3s ease;
+            border-radius: 10px;
         }
         @media (prefers-color-scheme: dark) {
             #progress-container {
@@ -61,17 +70,18 @@
                 background-color: #333;
             }
         }
-        h3 {
-            font-size: 0.9em;
+        #footer {
+            position: absolute;
+            bottom: 10px;
+            font-size: 0.8em;
             color: grey;
-            text-align: center;
         }
     </style>
 </head>
 <body>
 <div class="earthcal-app-logo" style="margin-bottom: 20px;"><img src="svgs/earthcal-icon.svg" style="width:125px;height:125px;"></div>
 <div id="progress-container"><div id="load-progress"></div></div>
-<h3>Loading Earthcal<span id="dots">...</span></h3>
+<div id="footer">Earthcal is developed by Earthen Labs.</div>
 
 <script type="module">
     const parseJwt = (tkn) => {
@@ -89,13 +99,6 @@
         const payload = parseJwt(token);
         return payload && (!payload.exp || payload.exp > Math.floor(Date.now() / 1000));
     };
-
-    const dotElem = document.getElementById("dots");
-    let dotPhase = 0;
-    setInterval(() => {
-        dotPhase = (dotPhase + 1) % 4;
-        dotElem.textContent = ".".repeat(dotPhase);
-    }, 400);
 
     const assets = [
         "js/earthcal-init.js",


### PR DESCRIPTION
## Summary
- remove redundant loading message
- apply `--general-background` variable for light/dark backgrounds
- round progress bar and add footer credit

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bbdcafb678832b9192e7c9410bef6c