### PR TITLE
Style dark mode and clock toggles

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -3175,3 +3175,59 @@ svg path #june:hover {
     margin-top: 100px;
 }
 }
+/* Toggle rows in settings */
+.toggle-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 5px 10px;
+    margin: 10px auto;
+    background: var(--general-background);
+    border-radius: 15px;
+    width: 260px;
+}
+
+.switch {
+    position: relative;
+    display: inline-block;
+    width: 50px;
+    height: 24px;
+}
+
+.switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+}
+
+.toggle-slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #b7bbbd;
+    transition: 0.4s;
+    border-radius: 24px;
+}
+
+.toggle-slider:before {
+    position: absolute;
+    content: "";
+    height: 18px;
+    width: 18px;
+    left: 3px;
+    bottom: 3px;
+    background-color: #fff;
+    transition: 0.4s;
+    border-radius: 50%;
+}
+
+.switch input:checked + .toggle-slider {
+    background-color: #4e5255;
+}
+
+.switch input:checked + .toggle-slider:before {
+    transform: translateX(26px);
+}

--- a/js/time-setting.js
+++ b/js/time-setting.js
@@ -227,6 +227,9 @@ async function showUserCalSettings() {
         `<option value="${key}" ${key.toLowerCase() === userLanguage.toLowerCase() ? 'selected' : ''}>${label}</option>`
     ).join('');
 
+    const mainClock = document.getElementById('main-clock');
+    const clockVisible = mainClock && mainClock.style.display === 'block';
+
     const modalContent = document.getElementById('modal-content');
     modalContent.innerHTML = `
         <div class="top-settings-icon"></div>
@@ -241,16 +244,22 @@ async function showUserCalSettings() {
                     ${languageOptions}
                 </select>
             </div>
-            <div class="compro-toggle" style="margin: 15px auto 10px auto; width: fit-content;">
-                <div style="text-align:center;">
-                    <dark-mode-toggle
-                        id="dark-mode-toggle-5" style="padding:10px;"
-                        class="slider"
-                        legend="${settingsContent.darkMode.legend}"
-                        remember="${settingsContent.darkMode.remember}"
-                        appearance="toggle">
-                    </dark-mode-toggle>
-                </div>
+            <div class="toggle-row">
+                <span>Toggle dark and light mode:</span>
+                <dark-mode-toggle
+                    id="dark-mode-toggle-5"
+                    class="slider"
+                    legend="${settingsContent.darkMode.legend}"
+                    remember="${settingsContent.darkMode.remember}"
+                    appearance="toggle">
+                </dark-mode-toggle>
+            </div>
+            <div class="toggle-row">
+                <span>Toggle clock view:</span>
+                <label class="switch">
+                    <input type="checkbox" id="clock-toggle" ${clockVisible ? 'checked' : ''} onchange="toggleClockView(this.checked)" aria-label="Toggle clock view">
+                    <span class="toggle-slider"></span>
+                </label>
             </div>
             <button type="button" name="apply" onclick="animateApplySettingsButton()" class="stellar-submit">
                 ${settingsContent.applySettings}
@@ -381,7 +390,15 @@ function openClock(time_zone = Intl.DateTimeFormat().resolvedOptions().timeZone)
     }
 }
 
-
+function toggleClockView(isChecked) {
+    const mainClock = document.getElementById('main-clock');
+    const isVisible = mainClock && mainClock.style.display === 'block';
+    if (isChecked && !isVisible) {
+        openClock(userTimeZone);
+    } else if (!isChecked && isVisible) {
+        openClock(userTimeZone);
+    }
+}
 
 let clockVisible = false;
 


### PR DESCRIPTION
## Summary
- Style dark-mode toggle within settings and add new clock-view toggle row
- Implement toggleClockView helper to show or hide the clock
- Add CSS for reusable toggle rows and switches

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2227799c832b888be015999a18e2