### PR TITLE
fix: preserve theme when opening settings

### DIFF
--- a/js/time-setting.js
+++ b/js/time-setting.js
@@ -267,6 +267,13 @@ async function showUserCalSettings() {
         </form>
     `;
 
+    const darkModeToggleEl = modalContent.querySelector('#dark-mode-toggle-5');
+    if (darkModeToggleEl) {
+        const isDark = Array.from(document.querySelectorAll('link[rel="stylesheet"]'))
+            .some(link => link.href.includes('dark.css') && link.media !== 'not all' && !link.disabled);
+        darkModeToggleEl.mode = isDark ? 'dark' : 'light';
+    }
+
     const contentBox = modal.querySelector('.modal-content-box');
     if (contentBox) {
         contentBox.id = 'modal-content-box';


### PR DESCRIPTION
## Summary
- ensure settings modal doesn't reset theme
- keep dark/light mode when opening Calendar Settings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd0857a384832baad3e74467781652