### PR TITLE
Show clock icons in settings toggle

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -3233,3 +3233,12 @@ svg path #june:hover {
 .toggle-switch input:checked + .toggle-slider:before {
     transform: translateX(26px);
 }
+
+/* Clock toggle icon styles */
+.toggle-slider.clock-toggle-slider:before {
+    background: #fff url('../icons/clock-off.svg') center/14px no-repeat;
+}
+
+.toggle-switch input:checked + .toggle-slider.clock-toggle-slider:before {
+    background: #fff url('../icons/clock-on.svg') center/14px no-repeat;
+}

--- a/js/time-setting.js
+++ b/js/time-setting.js
@@ -258,7 +258,7 @@ async function showUserCalSettings() {
                 <span>Toggle clock view:</span>
                 <label class="toggle-switch">
                     <input type="checkbox" id="clock-toggle" ${clockVisible ? 'checked' : ''} onchange="toggleClockView(this.checked)" aria-label="Toggle clock view">
-                    <span class="toggle-slider"></span>
+                    <span class="toggle-slider clock-toggle-slider"></span>
                 </label>
             </div>
             <div class="toggle-row">


### PR DESCRIPTION
## Summary
- display clock-on/off icons inside the settings toggle knob
- add CSS rules to swap icons based on toggle state

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd4e41e798832ba0f451c5ae955278