### PR TITLE
Enlarge settings toggles

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -3191,8 +3191,8 @@ svg path #june:hover {
 .toggle-switch {
     position: relative;
     display: inline-block;
-    width: 50px;
-    height: 24px;
+    width: 72px;
+    height: 32px;
 }
 
 .toggle-switch input {
@@ -3211,16 +3211,16 @@ svg path #june:hover {
     bottom: 0;
     background-color: #b7bbbd;
     transition: 0.4s;
-    border-radius: 24px;
+    border-radius: 32px;
 }
 
 .toggle-slider:before {
     position: absolute;
     content: "";
-    height: 18px;
-    width: 18px;
-    left: 3px;
-    bottom: 3px;
+    height: 24px;
+    width: 24px;
+    left: 4px;
+    bottom: 4px;
     background-color: #fff;
     transition: 0.4s;
     border-radius: 50%;
@@ -3231,14 +3231,14 @@ svg path #june:hover {
 }
 
 .toggle-switch input:checked + .toggle-slider:before {
-    transform: translateX(26px);
+    transform: translateX(40px);
 }
 
 /* Clock toggle icon styles */
 .toggle-slider.clock-toggle-slider:before {
-    background: #fff url('../icons/clock-off.svg') center/14px no-repeat;
+    background: #fff url('../icons/clock-off.svg') center/20px no-repeat;
 }
 
 .toggle-switch input:checked + .toggle-slider.clock-toggle-slider:before {
-    background: #fff url('../icons/clock-on.svg') center/14px no-repeat;
+    background: #fff url('../icons/clock-on.svg') center/20px no-repeat;
 }


### PR DESCRIPTION
## Summary
- Match clock and solar animation toggle dimensions with dark mode toggle
- Adjust slider dimensions, knob translation and clock icons for consistent sizing

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd5be9e3a4832b9a4461fc72dd4be3