### PR TITLE
Ensure planet animations wait for date initialization

### DIFF
--- a/dash.html
+++ b/dash.html
@@ -181,9 +181,10 @@
                 prefillAddDateCycle(cycleData);
             } else {
                 setCurrentDate(); // Fallback if no shared event
-            }
+                animatePlanetsIfReady();
+              }
 
-            const currentYear = parseInt(currentYearText.textContent); //gets the year from the currentYearText div
+              const currentYear = parseInt(currentYearText.textContent); //gets the year from the currentYearText div
 
             cyclesToggleSimplified();  // to show/hide animal cycles
             initializeToggleListener();  //to show or hide datecycles?
@@ -200,11 +201,13 @@
             // displayCurrentMoonPhase();
             updateMoonPhase(targetDate);
             // Initialize event listeners for the Sun SVG paths and reset the Moon phase to the current date
-            addDayPathEventListeners();
-            resetMoonPhase();
-            setTimeout(animatePlanetsIfReady, 1500);
-            setTimeout(function() {
+              addDayPathEventListeners();
+              resetMoonPhase();
+              setTimeout(function() {
                 startDate = targetDate;
+                if (params.get('action') === 'add-event') {
+                    animatePlanetsIfReady();
+                }
                 setYearsMonthsOn();
                 updateTargetMonth();
                 if (localStorage.getItem('buwana_id')) {

--- a/js/planet-orbits.js
+++ b/js/planet-orbits.js
@@ -25,6 +25,10 @@ class Planet {
     const orbitRatio1 = daysSinceYearStart / this.orbit_days;
     const orbitRatio2 = totalDays / this.orbit_days;
 
+    if (isNaN(orbitRatio1) || isNaN(orbitRatio2)) {
+      return;
+    }
+
     // Pre-calculate trigonometric values
     const orbitRadius = planetOrbitElement.r.baseVal.value;
     const finalCoords1 = {
@@ -120,16 +124,6 @@ const jupiter = new Planet("jupiter", "jupiter-orbit", 4333);
 const saturn = new Planet("saturn", "saturn-orbit", 10759);
 const uranus = new Planet("uranus", "uranus-orbit", 30687);
 const neptune = new Planet("neptune", "neptune-orbit", 60190);
-
-
-mercury.animate(startDate, targetDate);
-venus.animate(startDate, targetDate);
-earth.animate(startDate, targetDate);
-mars.animate(startDate, targetDate);
-jupiter.animate(startDate, targetDate);
-saturn.animate(startDate, targetDate);
-uranus.animate(startDate, targetDate);
-neptune.animate(startDate, targetDate);
 
 
 /*----------------------------------


### PR DESCRIPTION
## Summary
- guard planet animation when dates are missing
- remove eager planet animations and trigger only after date setup
- trigger planet animation after `setCurrentDate` completes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb5911a10832bb524ab2eca9f9e9e