### PR TITLE
feat: add animation toggles

### DIFF
--- a/dash.html
+++ b/dash.html
@@ -181,7 +181,11 @@
                 prefillAddDateCycle(cycleData);
             } else {
                 setCurrentDate(); // Fallback if no shared event
-                if (userAnimations) animatePlanetsIfReady();
+                if (userAnimations) {
+                    turnOnAnimations();
+                } else {
+                    turnOffAnimations();
+                }
               }
 
               const currentYear = parseInt(currentYearText.textContent); //gets the year from the currentYearText div
@@ -206,7 +210,11 @@
               setTimeout(function() {
                 startDate = targetDate;
                 if (params.get('action') === 'add-event') {
-                    if (userAnimations) animatePlanetsIfReady();
+                    if (userAnimations) {
+                        turnOnAnimations();
+                    } else {
+                        turnOffAnimations();
+                    }
                 }
                 setYearsMonthsOn();
                 updateTargetMonth();

--- a/js/planet-orbits.js
+++ b/js/planet-orbits.js
@@ -125,6 +125,38 @@ const saturn = new Planet("saturn", "saturn-orbit", 10759);
 const uranus = new Planet("uranus", "uranus-orbit", 30687);
 const neptune = new Planet("neptune", "neptune-orbit", 60190);
 
+let animationsEnabled = true;
+
+function turnOnAnimations() {
+  animationsEnabled = true;
+  animatePlanetsIfReady();
+}
+
+function turnOffAnimations() {
+  animationsEnabled = false;
+  if (!arePlanetsReady()) {
+    return;
+  }
+  const planets = [mercury, venus, earth, mars, jupiter, saturn, uranus, neptune];
+  const yearStart = new Date(2023, 0, 1);
+  const daysSinceYearStart = Math.floor((startDate - yearStart) / (1000 * 60 * 60 * 24));
+  const daysSinceTargetDate = Math.floor((targetDate - startDate) / (1000 * 60 * 60 * 24));
+  const totalDays = daysSinceYearStart + daysSinceTargetDate;
+  planets.forEach(planet => {
+    const planetElement = document.getElementById(planet.element_id);
+    const planetOrbitElement = document.getElementById(planet.orbit_id);
+    if (!planetElement || !planetOrbitElement) return;
+    planetElement.getAnimations().forEach(anim => anim.cancel());
+    const orbitRatio = totalDays / planet.orbit_days;
+    const orbitRadius = planetOrbitElement.r.baseVal.value;
+    const finalX = orbitRadius * Math.sin(2 * Math.PI * orbitRatio);
+    const finalY = orbitRadius * Math.cos(2 * Math.PI * orbitRatio);
+    planetElement.setAttribute("cx", finalX.toFixed(2) + "px");
+    planetElement.setAttribute("cy", finalY.toFixed(2) + "px");
+    planetElement.style.transform = `rotate(${orbitRatio * 360}deg)`;
+  });
+}
+
 
 /*----------------------------------
 
@@ -648,6 +680,16 @@ function arePlanetsReady() {
 }
 
 function animatePlanetsIfReady(retries = 10) {
+  if (!animationsEnabled) {
+    if (arePlanetsReady()) {
+      turnOffAnimations();
+    } else if (retries > 0) {
+      setTimeout(() => animatePlanetsIfReady(retries - 1), 300);
+    } else {
+      console.error("Planet elements still missing after multiple retries.");
+    }
+    return;
+  }
   if (arePlanetsReady()) {
     mercury.animate();
     venus.animate();

--- a/js/time-setting.js
+++ b/js/time-setting.js
@@ -464,15 +464,13 @@ function toggleSolarAnimations(isChecked) {
     userAnimations = isChecked;
     localStorage.setItem('user_animations', isChecked);
     if (isChecked) {
-        if (typeof animatePlanetsIfReady === 'function') {
-            animatePlanetsIfReady();
+        if (typeof turnOnAnimations === 'function') {
+            turnOnAnimations();
         }
     } else {
-        const planets = ['mercury','venus','earth','mars','jupiter','saturn','uranus','neptune'];
-        planets.forEach(id => {
-            const el = document.getElementById(id);
-            el?.getAnimations().forEach(anim => anim.cancel());
-        });
+        if (typeof turnOffAnimations === 'function') {
+            turnOffAnimations();
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- add `turnOnAnimations` and `turnOffAnimations` helpers for planet orbits
- wire settings toggle to enable or disable planet animations
- ensure non-animated planets jump directly to their target positions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68be5d668fd4832bac2c3762fe5e51e9