### PR TITLE
Refine login modal controls and blur effects

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -751,7 +751,7 @@ border-color: #00a112 !important;
 
 #day-search .x-button {
     top:25px;
-    left: 25px;
+    right:25px;
     }
 
 #right-settings-overlay .x-button {
@@ -2506,6 +2506,12 @@ color: #b2b1b1;
     text-align: left;
     padding: 10px;
     margin: auto;
+    position: relative;
+}
+
+#login-form-section .x-button {
+    top: 20px;
+    right: 20px;
 }
 
 
@@ -2519,14 +2525,7 @@ color: #b2b1b1;
     height: fit-content;
 }
 
-#reg-down-button {
-    border: none;
-    background-color: transparent;
-    cursor: pointer;
-    padding: 0;
-    z-index: 51;
-    display: none;
-}
+
 
 
 
@@ -2626,15 +2625,6 @@ color: #b2b1b1;
         height: 30px;
     }
 
-    #reg-down-button {
-        width: 15%;
-        margin: 20px auto 0px auto;
-        height: 12px;
-    }
-
-    #reg-down-button img {
-        height: 19px;
-    }
 }
 
 @media screen and (min-width: 701px) and (max-width: 1200px) {
@@ -2644,15 +2634,6 @@ color: #b2b1b1;
         margin-bottom: 5px;
     }
 
-    #reg-down-button {
-        width: 15%;
-        margin: 20px auto 0px auto;
-        height: 19px;
-    }
-
-    #reg-down-button img {
-        height: 19px;
-    }
 }
 
 @media screen and (min-width: 1201px) {
@@ -2662,15 +2643,6 @@ color: #b2b1b1;
         height: 40px;
     }
 
-    #reg-down-button {
-        width: 20%;
-        margin: 10px auto 25px auto;
-        height: 20px;
-    }
-
-    #reg-down-button img {
-        height: 20px;
-    }
 }
 
 

--- a/dash.html
+++ b/dash.html
@@ -322,6 +322,7 @@
         <div class="registration-footer-holder">
             <!--<div id="user-session-status" style="color:grey;font-size:small; width:100%; text-align:left; padding:10px;height: 12px;margin-top:-45px;font-family:'Mulish',sans-serif;"></div>-->
             <div class="form-container" id="login-form-section">
+                <button id="reg-down-button" type="button" onclick="sendDownRegistration()" aria-label="Hide Login" class="x-button"></button>
                 <div style="text-align:center;width:100%;" >
                     <div class="earthcal-app-logo" style="margin-bottom: 20px;"><img src="svgs/earthcal-icon.svg" style="width:125px;height:125px;"></div>
                     <div id="status-message">Login to EarthCal</div>
@@ -340,9 +341,6 @@
             <!--To be shown upon login-->
             <div id="logged-in-view" style="display:none; text-align:center;">
             </div>
-            <button id="reg-down-button" onclick="sendDownRegistration()" aria-label="Hide Login" data-lang-id="106-hide-subscription-registration">
-                <img src="svgs/down-arrow.svg" alt="Hide Earthen Newsletter registration" data-lang-id="107-hide-subscription-image-alt">
-            </button>
         </div>
     </div>
 </div>
@@ -808,7 +806,7 @@
         const modal = document.getElementById('form-modal-message');
         modal.classList.remove('modal-hidden');
         modal.classList.add('modal-visible');
-        document.getElementById("page-content").classList.add("blur");
+        modal.classList.add('dim-blur');
 
         document.getElementById('got-it-button').addEventListener('click', function () {
             closeTheModal();

--- a/js/calendar-scripts.js
+++ b/js/calendar-scripts.js
@@ -300,6 +300,8 @@ function closeTheModal() {
         box.style.backgroundColor = '';
     }
 
+    modal.classList.remove('dim-blur');
+
     // Hide the modal
     modal.classList.remove('modal-visible');
     modal.classList.add('modal-hidden');


### PR DESCRIPTION
## Summary
- Replace login footer arrow with a top-right `x-button` and clean up related styles
- Move day search modal close button to the top-right corner
- Use `dim-blur` overlay for intro modal and remove full-page blur on close

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bfadd2cfd4832b8b81921d87cdf87f