### PR TITLE
Rotate date arrows and reposition palette tray

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -3060,20 +3060,70 @@ svg path #june:hover {
 #date-controls {
     z-index: 29;
     position: fixed;
-    bottom: 2px;
-    left: 50%;
+    bottom: 20px;
+    right: 20px;
     background-color: var(--date-controls);
     border-radius: 15px;
-    padding: 10px 20px 0px 20px;
-    transform: translateX(-50%);
+    padding: 16px 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+#time-controller {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+}
+
+#date-controls .next-button,
+#date-controls .previous-button,
+#date-controls #reset-to-today {
+    margin: 0;
+}
+
+#date-controls .next-button,
+#date-controls .previous-button {
+    transform: rotate(90deg);
+    transform-origin: center;
+}
+
+#bottom-left-buttons {
+    display: flex;
+    position: fixed;
+    bottom: 20px;
+    left: 20px;
+    transform: none;
+    flex-direction: row;
+    align-items: center;
+    justify-content: flex-start;
+    gap: 12px;
+    width: fit-content;
+    max-width: calc(100vw - 260px);
+    flex-wrap: wrap;
+    background: var(--general-background);
+    padding: 15px 20px 10px 20px;
+    border-radius: 6px;
+    z-index: 20;
+}
+
+#bottom-left-buttons button {
+    margin: 0;
 }
 
 @media screen and (max-width: 700px) {
     #date-controls {
-        bottom: 27px;
+        bottom: 110px;
+        right: 15px;
     }
     #bottom-left-buttons {
-        right: 5px !important;
+        bottom: 20px;
+        left: 15px;
+        transform: none;
+        max-width: calc(100vw - 200px);
+        gap: 8px;
+        padding: 12px 16px;
     }
     #top-left-buttons {
         margin-left: 3px !important;

--- a/dash.html
+++ b/dash.html
@@ -611,7 +611,7 @@
         </div>
 
         <div id="date-controls">
-            <div id="time-controller" style="display: flex;flex-flow: row;width: 200px;height: 50px;">
+            <div id="time-controller">
                 <div id="next-year" class="next-button" aria-lable="Next Year" title="Go to next year"></div>
                 <div id="next-day" class="next-button" onclick="set2Tomorrow()" aria-lable="Next Day" title="Go to next day"></div>
                 <div id="reset-to-today" class="today-button" onclick="set2Today()" aria-lable="Today" title="Today"></div>
@@ -748,11 +748,7 @@
     </div>
 
     <!-- PALETTE MAIN BUTTONS -->
-    <div id="bottom-left-buttons" class="icon-button-columns" style="display: flex;width:fit-content;flex-direction: column;z-index:20; bottom:20px;right:20px;position:absolute; background: var(--general-background);
-      padding:
-    15px 0px 10px 0px;
-      border-radius:
-    6px;">
+    <div id="bottom-left-buttons" class="icon-button-columns">
         <button id="solarsystem-button" class="cycle-toggle" data-show="planet-buttons" data-hide="kin-buttons themoonphases americas-map euro-map moon-cycle moon-phase" title="Activate Planet Cycles" data-role="palette-root"></button>
         <button id="whale-earthbutton" class="cycle-toggle" data-show="kin-buttons" data-hide="planet-buttons themoonphases americas-map euro-map moon-cycle moon-phase" title="Activate ecological cycles" data-role="palette-root"></button>
         <button id="moon-button" class="cycle-toggle" data-show="moon-cycle moon-phase themoonphases" data-hide="planet-buttons kin-buttons americas-map euro-map" data-function="calculateHijriMonthNames" title="Activate lunar tracking" data-role="palette-root"></button>


### PR DESCRIPTION
## Summary
- rotate the date navigation arrows 90° so the icons follow the new vertical layout
- anchor the palette buttons tray to the bottom-left corner with a safe right margin to avoid the date controls
- update responsive rules so the palette tray keeps the new alignment on smaller screens

## Testing
- not run (layout updates only)

------
https://chatgpt.com/codex/tasks/task_e_68e21bc40fbc832baed03e788ec2199f