### PR TITLE
Stack bottom-left palette buttons vertically

### DIFF
--- a/css/1-stylesheet.css
+++ b/css/1-stylesheet.css
@@ -3082,8 +3082,8 @@ svg path #june:hover {
     left: 20px;
     transform: none;
     flex-direction: column;
-    align-items: flex-start;
-    justify-content: flex-end;
+    align-items: stretch;
+    justify-content: flex-start;
     gap: 12px;
     width: fit-content;
     background: var(--general-background);
@@ -3094,6 +3094,14 @@ svg path #june:hover {
 
 #bottom-left-buttons button {
     margin: 0;
+    width: 100%;
+}
+
+#planet-buttons,
+#kin-buttons {
+    flex-direction: row;
+    gap: 12px;
+    align-items: center;
 }
 
 @media screen and (max-width: 700px) {

--- a/js/kin-cycles.js
+++ b/js/kin-cycles.js
@@ -41,18 +41,39 @@ function cyclesToggleSimplified() {
       const paletteWidth = paletteRect.width;
       const paletteHeight = paletteRect.height;
 
-      const centredLeft = buttonRect.left + (buttonRect.width / 2) - (paletteWidth / 2);
-      const maxLeft = window.innerWidth - paletteWidth - viewportPadding;
-      const clampedLeft = Math.max(viewportPadding, Math.min(centredLeft, maxLeft));
+      const shouldAlignRight =
+        triggerButton.dataset.role === "palette-root" &&
+        (paletteId === "planet-buttons" || paletteId === "kin-buttons");
 
-      let top = buttonRect.top - paletteHeight - gap;
-      if (top < viewportPadding) {
-        top = buttonRect.bottom + gap;
+      let left;
+      let top;
+
+      if (shouldAlignRight) {
+        const preferredLeft = buttonRect.right + gap;
+        const maxLeft = window.innerWidth - paletteWidth - viewportPadding;
+        if (preferredLeft + paletteWidth > window.innerWidth - viewportPadding) {
+          left = Math.max(viewportPadding, buttonRect.left - paletteWidth - gap);
+        } else {
+          left = Math.min(preferredLeft, maxLeft);
+        }
+
+        const preferredTop = buttonRect.top + (buttonRect.height / 2) - (paletteHeight / 2);
+        const maxTop = window.innerHeight - paletteHeight - viewportPadding;
+        top = Math.max(viewportPadding, Math.min(preferredTop, maxTop));
+      } else {
+        const centredLeft = buttonRect.left + (buttonRect.width / 2) - (paletteWidth / 2);
+        const maxLeft = window.innerWidth - paletteWidth - viewportPadding;
+        left = Math.max(viewportPadding, Math.min(centredLeft, maxLeft));
+
+        top = buttonRect.top - paletteHeight - gap;
+        if (top < viewportPadding) {
+          top = buttonRect.bottom + gap;
+        }
+        const maxTop = window.innerHeight - paletteHeight - viewportPadding;
+        top = Math.min(top, maxTop);
       }
-      const maxTop = window.innerHeight - paletteHeight - viewportPadding;
-      top = Math.min(top, maxTop);
 
-      palette.style.left = `${clampedLeft}px`;
+      palette.style.left = `${left}px`;
       palette.style.top = `${top}px`;
       palette.style.visibility = "visible";
     });


### PR DESCRIPTION
## Summary
- stack the bottom-left palette root buttons vertically with full-width styling
- present the planet and kin palettes as horizontal rows positioned beside their triggers for clarity
- update palette positioning logic so the menus open beside their associated buttons while preserving fallback behaviour elsewhere

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e239a712fc832b8c93f89aad95c4ef