### PR TITLE
Add placeholder item management entry point

### DIFF
--- a/api/v1/add_item.php
+++ b/api/v1/add_item.php
@@ -1,0 +1,2 @@
+<?php
+// Placeholder for add item endpoint.

--- a/js/earthcal-init.js
+++ b/js/earthcal-init.js
@@ -33,6 +33,7 @@ async function initCalendar() {
         "js/set-targetdate.js",
         "js/planet-orbits.js",
         "js/login-scripts.js",
+        "js/item-management.js",
         "js/time-setting.js",
         "js/calendar-scripts.js",
     ];

--- a/js/item-management.js
+++ b/js/item-management.js
@@ -1,0 +1,5 @@
+function openAddItem() {
+  alert('Open Add Item function was called!');
+}
+
+window.openAddItem = openAddItem;

--- a/js/time-setting.js
+++ b/js/time-setting.js
@@ -39,7 +39,7 @@ async function displayUserData(time_zone, language) {
         userTimezoneLangDiv.innerHTML = `
             <span id="current-user-time"></span>
             <span id="user-details" style="cursor:pointer"
-                onclick="showUserCalSettings()"
+                onclick="openAddItem()"
                 onmouseover="this.style.textDecoration='underline'"
                 onmouseout="this.style.textDecoration='none'">
                 ${userDetailsString}


### PR DESCRIPTION
## Summary
- add a placeholder item-management script that exposes an `openAddItem` alert helper
- load the new script during dashboard initialization and wire the user details link to it
- scaffold an `api/v1/add_item.php` endpoint file for future item handling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e23b34bbf0832b9dca617c3528d13f